### PR TITLE
docs(openspec): propose cuVSLAM VIO integration

### DIFF
--- a/openspec/changes/add-cuvslam-vio/.openspec.yaml
+++ b/openspec/changes/add-cuvslam-vio/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/add-cuvslam-vio/design.md
+++ b/openspec/changes/add-cuvslam-vio/design.md
@@ -1,0 +1,127 @@
+## Context
+
+The rover already supports several odometry paths that feed RTAB-Map, Nav2, and PX4 through the shared `/odometry/filtered` interface: RTAB-Map RGB-D visual odometry, ICP odometry, Intel T265 built-in VIO, and VINS-Fusion using the T265 fisheye stereo pair plus IMU. The repo's current CUDA story is split by architecture: x86_64 builds lean on a mounted desktop CUDA 12.x toolchain, while Jetson Xavier builds use CUDA 11.4 with GCC 11, shared CUDA runtime linkage, and a glibc compatibility header to keep Ubuntu 24.04 workable.
+
+cuVSLAM is attractive because it is open source, CUDA-first, and already structured as a native library rather than a monolithic ROS application. At the same time, the repo wants to stay lean: adding Isaac ROS Visual SLAM would bring a large dependency tree that does not fit the existing Docker image or bringup pattern. The change is therefore cross-cutting across Docker, dependency tooling, top-level launch orchestration, SLAM odometry selection, and T265 hardware behavior.
+
+The largest uncertainty is whether cuVSLAM source builds really remain viable on Jetson Xavier's CUDA 11.4 stack even though the upstream README calls out CUDA 12/13 for prebuilt binaries. That uncertainty needs to be made explicit in the design rather than assumed away.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add cuVSLAM as a selectable stereo fisheye + IMU odometry source alongside VINS-Fusion, T265 built-in odometry, RTAB-Map VO, and ICP.
+- Reuse the existing T265 fisheye and IMU path so no new camera hardware or topic families are required.
+- Keep cuVSLAM in odometry-only mode so RTAB-Map continues to own mapping and `map -> odom`.
+- Preserve the rover's odometry and TF contracts by relaying cuVSLAM output into `odom -> ackermann/base_link`.
+- Define an architecture-aware build path for x86_64 and Jetson Xavier that follows the repo's existing CUDA toolchain conventions.
+- Insert a hard phase-0 stop/go gate so Xavier source compilation and smoke linking are proven before the rest of the implementation is treated as viable.
+
+**Non-Goals:**
+- Replacing RTAB-Map as the SLAM or mapping system.
+- Removing or deprecating VINS-Fusion, T265 built-in odometry, RTAB-Map VO, or ICP.
+- Pulling in Isaac ROS NITROS/GXF/GEM dependency chains as part of this change.
+- Using Python bindings as the primary cuVSLAM execution path.
+- Treating prebuilt cuVSLAM binaries as a requirement on Jetson Xavier.
+
+## Decisions
+
+### Validate source builds first, then integrate
+
+The change starts with a dedicated phase-0 validation build on Jetson Xavier and x86_64 instead of assuming README wording about CUDA 12/13 applies to source compilation.
+
+Rationale:
+- The current evidence is encouraging but indirect: the source tree appears to avoid hard CUDA-version gating and the existing repo already solves the same GCC 11, shared-cudart, and glibc-compatibility issues for Jetson CUDA work.
+- The rest of the integration touches several subsystems and is not worth pursuing if Xavier compilation fails early.
+
+Alternatives considered:
+- Integrate the wrapper first and troubleshoot build issues later. Rejected because it increases the amount of speculative work.
+- Depend on upstream prebuilt binaries. Rejected because that excludes Xavier's CUDA 11.4 environment.
+
+### Use a thin ROS 2 C++ wrapper around `cuvslam2.h`
+
+The repo will integrate cuVSLAM by building the library from source and adding a small native ROS 2 C++ node in `src/cuvslam_bringup/`.
+
+Rationale:
+- This matches the repo's current bringup style better than Isaac ROS packages.
+- It keeps the dependency graph narrow and localizes ownership of ROS topics, frame conversion, and lifecycle behavior inside one package.
+- It avoids Python per-frame overhead and GIL contention on Xavier's limited CPU budget.
+
+Alternatives considered:
+- Isaac ROS Visual SLAM wrapper. Rejected because the dependency chain is too heavy for the current Docker image and workflow.
+- Python bindings. Rejected because 30 Hz stereo VIO on Xavier leaves little CPU headroom for interpreter overhead.
+
+### Reuse T265 fisheye and IMU topics and build the rig from live CameraInfo
+
+cuVSLAM will subscribe to the existing `/t265/fisheye1/image_raw`, `/t265/fisheye2/image_raw`, `/t265/fisheye1/camera_info`, `/t265/fisheye2/camera_info`, and `/t265/imu` topics. The wrapper will construct the cuVSLAM rig from the first valid CameraInfo pair and use YAML configuration only for wrapper behavior, topic names, and launch-time policy.
+
+Rationale:
+- It avoids maintaining a second source of truth for the T265 intrinsics when the RealSense driver already publishes them.
+- It follows the user's desired wrapper lifecycle and keeps the integration closer to the live sensor contract.
+- It lets VINS-Fusion keep its own static calibration files without forcing cuVSLAM into the same configuration model.
+
+Alternatives considered:
+- Hard-code all camera intrinsics/extrinsics in YAML as VINS-Fusion does. Rejected because it duplicates calibration data and makes drift between driver output and wrapper assumptions more likely.
+
+### Keep cuVSLAM odometry-only and preserve `/odometry/filtered`
+
+cuVSLAM will act only as an external odometry source. RTAB-Map will remain the mapping owner, `robot_localization` will continue to publish `/odometry/filtered`, and Nav2/PX4 will keep consuming that filtered output.
+
+Rationale:
+- This keeps the rest of the stack unchanged.
+- It preserves the repo's current comparison model where multiple raw odometry topics can coexist while downstream systems stay wired to `/odometry/filtered`.
+- It aligns with Xavier's memory constraints by avoiding additional mapping or loop-closure work inside the cuVSLAM path.
+
+Alternatives considered:
+- Feed cuVSLAM directly to downstream consumers. Rejected because it would change stable system contracts.
+- Let cuVSLAM own mapping. Rejected because RTAB-Map already fills that role and the requested mode is odometry-only.
+
+### Mirror the repo's architecture-aware CUDA toolchain conventions
+
+The cuVSLAM dependency tooling will follow the same architecture split documented for VINS-Fusion:
+- x86_64 builds use the mounted host CUDA toolkit under `/usr/local/cuda` and can target the local desktop GPU architecture.
+- Jetson Xavier builds force GCC 11 as the C, C++, and CUDA host compiler, use `CUDA_RUNTIME_LIBRARY=Shared`, inject `realsense_camera_bringup/cuda_glibc_compat.h` during CUDA compilation, and keep parallelism conservative (`make -j2`).
+- Built artifacts are cached under an architecture-qualified prefix such as `/workspace/docker_cache/cuvslam/<arch>/current` so x86_64 and aarch64 outputs never collide.
+
+Rationale:
+- These patterns are already proven elsewhere in the repo.
+- They directly address the known Xavier failure modes: static CUDA runtime link errors, Ubuntu 24.04 glibc parsing issues, and memory pressure during native builds.
+
+Alternatives considered:
+- Use a single unqualified build cache. Rejected because the binaries and generated CMake metadata are architecture-specific.
+- Treat x86_64 and Xavier as separate one-off scripts. Rejected because the repo already has a reusable architecture-aware pattern.
+
+### Give cuVSLAM highest priority among external VIO modes
+
+When multiple external-VIO launch flags are enabled, the SLAM stack will choose cuVSLAM ahead of VINS-Fusion and T265 built-in odometry. VINS-Fusion will remain ahead of T265 built-in odometry.
+
+Rationale:
+- The user's intent is to integrate cuVSLAM as the preferred GPU-accelerated alternative while still preserving the older modes for debugging and fallback.
+- Making the priority explicit avoids ambiguous behavior if multiple flags are accidentally enabled.
+
+Alternatives considered:
+- Reject launches with more than one external-VIO flag. Rejected because the repo often keeps non-selected odometry producers available for comparison, and explicit priority is simpler operationally.
+
+## Risks / Trade-offs
+
+- [cuVSLAM source build still fails on Xavier CUDA 11.4] -> Make phase 0 a stop/go gate and avoid promising full integration success before that build passes.
+- [T265 fisheye model or extreme edge FOV degrades cuVSLAM tracking] -> Start with full-frame support but validate stationary drift and motion paths against VINS-Fusion and T265 built-in odometry.
+- [Jetson memory pressure during native compilation] -> Use conservative parallelism, cache built artifacts, and keep cuVSLAM in odometry-only mode.
+- [Static CUDA linkage pulls incompatible system libraries on Ubuntu 24.04] -> Force shared CUDA runtime linkage in the cuVSLAM build path.
+- [Frame or coordinate conventions differ from ROS ENU/FLU expectations] -> Relay raw cuVSLAM output through the existing odom adapter before exposing it to EKF and the rest of the stack.
+- [Keeping VINS-Fusion and cuVSLAM side by side complicates launch logic] -> Centralize source selection in `robot_bringup` and `rtabmap_slam` with explicit priority rules.
+
+## Migration Plan
+
+1. Vendor cuVSLAM under `src/` and implement the phase-0 build and smoke-link workflow for x86_64 and Jetson Xavier.
+2. Add the `cuvslam_bringup` package with CameraInfo-driven rig initialization, stereo/IMU subscriptions, odometry publishing, and `odom_tf_relay` integration.
+3. Extend `robot_bringup` to expose `use_cuvslam_odom` and reuse the existing T265 enable/fisheye orchestration in hardware mode.
+4. Extend `rtabmap_slam` and EKF source selection to prefer cuVSLAM when requested while preserving the existing raw odometry topics for comparison.
+5. Update build scripts and docs so operators can build, launch, and validate cuVSLAM through the repo's normal workflows.
+6. Roll back by disabling `use_cuvslam_odom`; downstream systems remain unchanged because `/odometry/filtered` stays the stable interface.
+
+## Open Questions
+
+- Which upstream cuVSLAM commit or tag becomes the pinned submodule reference after the phase-0 build passes?
+- Does cuVSLAM need image masking or central-region cropping for the T265's widest fisheye edges, or is the default fisheye model sufficient?
+- What covariance mapping and failure-state behavior should the wrapper publish when cuVSLAM tracking is initializing, degraded, or lost?
+- Should the x86_64 path cache only the final cuVSLAM install tree, or also preserve an intermediate build directory for faster local iteration?

--- a/openspec/changes/add-cuvslam-vio/proposal.md
+++ b/openspec/changes/add-cuvslam-vio/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The rover now has two practical external VIO paths: Intel T265 built-in odometry and VINS-Fusion running on the T265 fisheye stereo pair. On Jetson Xavier NX, VINS-Fusion is usable but still compute-limited, while cuVSLAM offers a GPU-first stereo VIO path that is more aligned with the Xavier's CUDA hardware and can run in odometry-only mode while RTAB-Map continues to own mapping.
+
+The main uncertainty is build viability on Jetson Xavier's CUDA 11.4 toolchain because cuVSLAM's README calls out CUDA 12/13 for prebuilt binaries. The source-level review and the existing VINS CUDA setup in this repo suggest the Xavier path is still plausible, so the change needs a formal validation gate before deeper integration work starts.
+
+## What Changes
+
+- Add a selectable cuVSLAM-based stereo visual-inertial odometry path that consumes the T265 fisheye cameras and IMU.
+- Add a thin ROS 2 C++ wrapper package that builds a cuVSLAM rig from CameraInfo, forwards stereo frames and IMU measurements, and publishes rover-compatible odometry.
+- Extend top-level bringup with `use_cuvslam_odom` orchestration and reuse the existing T265 fisheye enablement path in hardware mode.
+- Extend SLAM/EKF odometry-source selection so cuVSLAM becomes the highest-priority external VIO source when enabled, ahead of VINS-Fusion and T265 built-in odometry.
+- Add Docker and build-tooling support for source-building cuVSLAM on both x86_64 and Jetson Xavier, reusing the repo's CUDA compatibility patterns where possible.
+- Add an explicit phase-0 stop/go validation step so Xavier source compilation and smoke-linking are proven before the rest of the integration is treated as implementation-ready.
+
+## Capabilities
+
+### New Capabilities
+- `cuvslam-vio`: GPU-accelerated stereo fisheye + IMU visual-inertial odometry using cuVSLAM, including source-build validation, ROS 2 wrapper behavior, topic contracts, and rover-frame odometry output.
+
+### Modified Capabilities
+- `robot-bringup`: add `use_cuvslam_odom` launch orchestration and propagate cuVSLAM mode into the existing hardware and SLAM bringup flow.
+- `slam`: extend external odometry selection and EKF behavior so cuVSLAM can be selected ahead of VINS-Fusion, T265 built-in odometry, RGB-D VO, and ICP.
+- `realsense-camera`: confirm that top-level T265 fisheye enablement semantics cover cuVSLAM as well as VINS-Fusion consumers.
+
+## Impact
+
+- Affected code: new `src/cuvslam_bringup/` package, new `docker/install_cuvslam_deps.sh`, new `scripts/build_cuvslam.sh`, `docker/Dockerfile`, `src/robot_bringup/launch/robot_bringup.launch.py`, `src/rtabmap_bringup/launch/rtabmap_slam.launch.py`, and a new cuVSLAM submodule under `src/`.
+- Affected systems: Docker image build, x86_64 and Jetson Xavier CUDA toolchain handling, T265 fisheye hardware workflows, EKF odometry-source selection, RTAB-Map input selection, and downstream Nav2/PX4 consumers of `/odometry/filtered`.
+- Dependency surface: cuVSLAM source tree, `liblmdb-dev`, CUDA host-compiler selection, shared-vs-static CUDA runtime linkage, and reuse of the repo's existing glibc/CUDA compatibility header for Jetson builds.

--- a/openspec/changes/add-cuvslam-vio/specs/cuvslam-vio/spec.md
+++ b/openspec/changes/add-cuvslam-vio/specs/cuvslam-vio/spec.md
@@ -1,0 +1,76 @@
+## Architecture / Data Flow
+
+```
+T265 Fisheye (848x800 @30Hz) + IMU (@200 Hz)
+  → realsense_camera_node (fisheye auto-enabled when use_cuvslam_odom:=true)
+  → /t265/fisheye1/image_raw, /t265/fisheye2/image_raw
+  → /t265/fisheye1/camera_info, /t265/fisheye2/camera_info, /t265/imu
+  → [cuvslam_odom_node] (CameraInfo-driven rig init, stereo VIO, IMU integration)
+  → /cuvslam/raw_odometry
+  → [odom_tf_relay] (frame adaptation: sensor-native pose → ackermann/base_link)
+  → /cuvslam_odom (odom → ackermann/base_link)
+  → EKF (odom0, IMU yaw fusion disabled for external VIO)
+  → /odometry/filtered → RTAB-Map / Nav2 / PX4
+```
+
+**Odometry priority**: cuVSLAM > VINS-Fusion > T265 built-in > RGB-D VO > ICP
+
+**Key nodes**:
+- `cuvslam_odom_node` (`cuvslam_bringup`) — cuVSLAM ROS 2 wrapper that owns rig setup, stereo sync, IMU forwarding, and raw odometry publication
+- `cuvslam_odom_relay` (`realsense_camera_bringup/odom_tf_relay`) — adapts raw cuVSLAM output to the rover frame contract
+- `robot_localization` EKF — fuses `/cuvslam_odom` as `odom0` when cuVSLAM is selected
+
+**Key files**:
+- `src/cuvslam_bringup/src/cuvslam_odom_node.cpp` — wrapper node around `cuvslam2.h`
+- `src/cuvslam_bringup/config/t265_stereo_fisheye.yaml` — wrapper configuration and topic policy
+- `src/cuvslam_bringup/launch/cuvslam.launch.py` — cuVSLAM launch + relay wiring
+- `docker/install_cuvslam_deps.sh` — architecture-aware cuVSLAM source build tooling
+- `scripts/build_cuvslam.sh` — workspace build entrypoint for cuVSLAM integration
+
+## ADDED Requirements
+
+### Requirement: Selectable cuVSLAM odometry bringup
+The system SHALL provide a cuVSLAM bringup path that consumes T265 stereo fisheye images and IMU data as a selectable visual-inertial odometry source.
+
+#### Scenario: Standalone cuVSLAM bringup
+- **WHEN** the cuVSLAM bringup launch is started with T265 fisheye images, CameraInfo, and IMU topics available
+- **THEN** the cuVSLAM wrapper SHALL subscribe to the T265 stereo fisheye and IMU topics and publish a raw odometry output for downstream adaptation
+
+### Requirement: CameraInfo-driven rig initialization
+The cuVSLAM wrapper SHALL initialize its stereo rig from the live T265 CameraInfo topics before tracking frames.
+
+#### Scenario: First valid stereo calibration received
+- **WHEN** the wrapper receives a valid left and right CameraInfo pair for the selected fisheye topics
+- **THEN** it SHALL build the cuVSLAM rig from those messages before invoking frame tracking
+
+### Requirement: Rover-frame odometry adaptation
+The system SHALL adapt cuVSLAM odometry into the rover's standard odometry contract before exposing it to EKF and other consumers.
+
+#### Scenario: Adapted cuVSLAM odometry output
+- **WHEN** cuVSLAM odometry is active
+- **THEN** the odometry exposed to the rest of the stack as `/cuvslam_odom` SHALL use `frame_id=odom` and `child_frame_id=ackermann/base_link`
+
+### Requirement: Odometry-only cuVSLAM integration
+The cuVSLAM integration SHALL operate as an odometry provider and SHALL not replace RTAB-Map as the mapping owner in the rover stack.
+
+#### Scenario: cuVSLAM active with RTAB-Map
+- **WHEN** cuVSLAM is selected while RTAB-Map SLAM is enabled
+- **THEN** cuVSLAM SHALL provide odometry only and RTAB-Map SHALL remain responsible for `/map` publication and the `map -> odom` transform
+
+### Requirement: Architecture-aware cuVSLAM source build path
+The system SHALL provide a validated source-build path for cuVSLAM in the Docker environment on both x86_64 and Jetson Xavier-class aarch64 targets.
+
+#### Scenario: x86_64 source build
+- **WHEN** the cuVSLAM dependency build is run on an x86_64 target with the host CUDA toolkit mounted into the container
+- **THEN** the build tooling SHALL configure cuVSLAM against that toolkit, install an architecture-qualified artifact cache, and provide a smoke-testable library output
+
+#### Scenario: Jetson Xavier source build
+- **WHEN** the cuVSLAM dependency build is run on a Jetson Xavier-class aarch64 target with CUDA 11.4-era tooling
+- **THEN** the build tooling SHALL use a compatible GCC 11 host compiler, shared CUDA runtime linkage, and the repo's CUDA/glibc compatibility pattern so the library can be compiled and smoke-tested from source
+
+### Requirement: Preserved odometry-source comparability
+The system SHALL preserve access to the existing odometry topics when cuVSLAM is introduced so operators can compare cuVSLAM with the other odometry sources.
+
+#### Scenario: Debugging alongside other odometry sources
+- **WHEN** cuVSLAM is selected as the active odometry source
+- **THEN** the stack SHALL continue publishing the non-selected odometry topics needed for debugging and comparison, including VINS-Fusion, RTAB-Map VO/ICP, and T265 built-in odometry where their producers are enabled

--- a/openspec/changes/add-cuvslam-vio/specs/realsense-camera/spec.md
+++ b/openspec/changes/add-cuvslam-vio/specs/realsense-camera/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Top-level fisheye enablement compatibility
+The RealSense bringup SHALL accept top-level launch control for T265 fisheye stream enablement so higher-level bringup can activate VINS-Fusion or cuVSLAM prerequisites without manual per-camera overrides.
+
+#### Scenario: Top-level launch requests stereo-fisheye VIO prerequisites
+- **WHEN** higher-level bringup selects a VINS-Fusion-based or cuVSLAM-based odometry mode
+- **THEN** the RealSense launch SHALL honor the passed T265 fisheye enablement argument and start the required fisheye streams
+
+#### Scenario: Stereo-fisheye VIO mode not selected
+- **WHEN** the T265 hardware path is enabled but higher-level bringup has not selected a VINS-Fusion-based or cuVSLAM-based odometry mode
+- **THEN** the RealSense launch SHALL keep T265 fisheye stream publishing disabled

--- a/openspec/changes/add-cuvslam-vio/specs/robot-bringup/spec.md
+++ b/openspec/changes/add-cuvslam-vio/specs/robot-bringup/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: cuVSLAM odometry mode orchestration
+The top-level bringup SHALL expose a `use_cuvslam_odom` launch mode that orchestrates the required hardware and subsystem configuration for cuVSLAM odometry.
+
+#### Scenario: Hardware bringup with cuVSLAM odometry
+- **WHEN** `use_gazebo:=false` and `use_cuvslam_odom:=true`
+- **THEN** `robot_bringup.launch.py` SHALL enable the T265 hardware path, enable the T265 fisheye streams needed by cuVSLAM, and include the cuVSLAM bringup launch
+
+### Requirement: cuVSLAM mode propagation to SLAM bringup
+The top-level bringup SHALL pass cuVSLAM odometry selection into the SLAM bringup so downstream odometry-source selection is consistent.
+
+#### Scenario: RTAB-Map launched with cuVSLAM mode
+- **WHEN** `rtabmap:=true` and `use_cuvslam_odom:=true`
+- **THEN** the RTAB-Map bringup include SHALL receive launch arguments that select cuVSLAM-derived odometry as the preferred external odometry source

--- a/openspec/changes/add-cuvslam-vio/specs/slam/spec.md
+++ b/openspec/changes/add-cuvslam-vio/specs/slam/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: EKF sensor fusion
+The system SHALL fuse the selected odometry source and IMU data using a robot_localization EKF at 30 Hz in 2D mode, publishing `/odometry/filtered` in ENU/FLU convention.
+
+#### Scenario: Filtered odometry with RTAB-Map VO or ICP
+- **WHEN** the EKF is running with RTAB-Map visual odometry or ICP selected as odom0
+- **THEN** `/odometry/filtered` SHALL fuse odom0 with IMU angular-rate data needed to stabilize heading
+
+#### Scenario: Filtered odometry with external VIO
+- **WHEN** the EKF is running with cuVSLAM, VINS-Fusion, or T265 built-in odometry selected as odom0
+- **THEN** `/odometry/filtered` SHALL use the selected external VIO odometry as odom0 and SHALL disable the redundant IMU yaw-rate fusion that would double-count heading information
+
+### Requirement: External VIO odometry source selection
+The SLAM stack SHALL support cuVSLAM and VINS-Fusion as external odometry sources in addition to T265 built-in odometry, RTAB-Map visual odometry, and ICP odometry.
+
+#### Scenario: cuVSLAM selected as odometry source
+- **WHEN** `use_cuvslam_odom:=true`
+- **THEN** the SLAM stack SHALL use `/cuvslam_odom` as the odometry input consumed by RTAB-Map and the EKF
+
+#### Scenario: cuVSLAM takes priority over other external VIO modes
+- **WHEN** `use_cuvslam_odom:=true` and one or more lower-priority external VIO flags are also enabled
+- **THEN** the SLAM stack SHALL keep `/cuvslam_odom` as the selected odometry input
+
+#### Scenario: VINS selected as odometry source
+- **WHEN** `use_cuvslam_odom:=false` and `use_vins_odom:=true`
+- **THEN** the SLAM stack SHALL use `/vins_odom` as the odometry input consumed by RTAB-Map and the EKF
+
+#### Scenario: T265 built-in odometry selected
+- **WHEN** `use_cuvslam_odom:=false` and `use_vins_odom:=false` and `use_t265_odom:=true`
+- **THEN** the SLAM stack SHALL use the relayed T265 odometry topic as the odometry input consumed by RTAB-Map and the EKF

--- a/openspec/changes/add-cuvslam-vio/tasks.md
+++ b/openspec/changes/add-cuvslam-vio/tasks.md
@@ -1,0 +1,28 @@
+## 1. Phase-0 validation and dependency tooling
+
+- [ ] 1.1 Vendor cuVSLAM under `src/` at a pinned upstream ref and document the chosen commit or tag for the change.
+- [ ] 1.2 Add `docker/install_cuvslam_deps.sh` with architecture-aware cache paths, CUDA toolkit detection, GCC 11 host-compiler handling, shared CUDA runtime linkage, and Jetson glibc-compatibility flags.
+- [ ] 1.3 Update Docker dependencies such as `docker/Dockerfile` so the container has the packages needed to configure and build cuVSLAM from source.
+- [ ] 1.4 Add a phase-0 smoke test that links against the built cuVSLAM library and confirms the library can be loaded after the dependency build completes.
+- [ ] 1.5 Run the phase-0 source-build workflow on the supported x86_64 and Jetson Xavier paths and record whether the change can proceed past the stop/go gate.
+
+## 2. cuVSLAM bringup package
+
+- [ ] 2.1 Create `src/cuvslam_bringup/` with package metadata, CMake wiring, launch files, and configuration assets.
+- [ ] 2.2 Implement `cuvslam_odom_node.cpp` to initialize the cuVSLAM rig from CameraInfo, synchronize stereo images, forward IMU measurements, and publish raw odometry.
+- [ ] 2.3 Wire `odom_tf_relay` into `cuvslam.launch.py` so the exposed `/cuvslam_odom` topic conforms to `odom -> ackermann/base_link`.
+- [ ] 2.4 Verify the standalone cuVSLAM bringup path publishes the expected topics and frame IDs before integrating it into the full stack.
+
+## 3. Top-level launch and SLAM integration
+
+- [ ] 3.1 Add `use_cuvslam_odom` handling to `src/robot_bringup/launch/robot_bringup.launch.py`, including automatic T265 and fisheye enablement in hardware mode.
+- [ ] 3.2 Extend `src/rtabmap_bringup/launch/rtabmap_slam.launch.py` so odometry selection prefers cuVSLAM over VINS-Fusion and T265 built-in odometry when requested.
+- [ ] 3.3 Update EKF configuration and launch wiring so external-VIO yaw fusion is disabled consistently when cuVSLAM is the selected odometry source.
+- [ ] 3.4 Extend operator-facing scripts and docs so cuVSLAM can be built, launched, and debugged through the repo's normal workflows.
+
+## 4. Verification and comparison
+
+- [ ] 4.1 Run the required Docker-side workspace build and test commands after the cuVSLAM integration changes land.
+- [ ] 4.2 Validate standalone T265 + cuVSLAM operation, including `/cuvslam_odom`, `/odometry/filtered`, TF stability, and retained comparison topics.
+- [ ] 4.3 Compare stationary drift, motion tracking, and runtime cost against VINS-Fusion and T265 built-in odometry on the target hardware.
+- [ ] 4.4 Run the AGENTS.md end-to-end validation checklist with `use_cuvslam_odom:=true` and record any remaining gaps or blockers.


### PR DESCRIPTION
## Summary
- add an OpenSpec change for integrating cuVSLAM as a selectable stereo fisheye + IMU VIO source
- capture the Xavier/x86_64 CUDA build strategy and make Xavier source compilation a phase-0 stop/go gate
- define the required deltas for `robot-bringup`, `slam`, and `realsense-camera`, plus implementation tasks

## Validation
- `openspec validate add-cuvslam-vio`

## Notes
- This PR contains the OpenSpec proposal/design/spec/tasks only
- It does not implement the cuVSLAM integration yet
