### PR TITLE
fix(vins): package Jetson tuning updates

### DIFF
--- a/docker/install_vins_gpu_deps.sh
+++ b/docker/install_vins_gpu_deps.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 OPENCV_VERSION="${OPENCV_VERSION:-4.10.0}"
-OPENCV_CACHE_ROOT="${OPENCV_CACHE_ROOT:-/workspace/docker_cache/opencv-cuda}"
+_ARCH="$(uname -m)"
+OPENCV_CACHE_ROOT="${OPENCV_CACHE_ROOT:-/workspace/docker_cache/opencv-cuda/${_ARCH}}"
 OPENCV_PREFIX_VERSIONED="${OPENCV_PREFIX_VERSIONED:-${OPENCV_CACHE_ROOT}/${OPENCV_VERSION}}"
 OPENCV_PREFIX_LINK="${OPENCV_PREFIX_LINK:-${OPENCV_CACHE_ROOT}/current}"
 OPENCV_BUILD_ROOT="${OPENCV_BUILD_ROOT:-/tmp/opencv-cuda-build}"

--- a/docs/architecture/vins_fusion_vio.md
+++ b/docs/architecture/vins_fusion_vio.md
@@ -1,0 +1,273 @@
+---
+title: VINS-Fusion Visual-Inertial Odometry
+status: Draft
+last_updated: 2026-04-11
+doc_type: architecture
+---
+
+## Overview
+
+VINS-Fusion provides a stereo visual-inertial odometry (VIO) path using the
+T265 fisheye cameras and IMU.  It runs as an alternative to the T265 built-in
+VIO and RTAB-Map visual odometry, selectable at launch time with
+`use_vins_odom:=true`.
+
+### Data Flow
+
+```
+T265 Fisheye (848x800 @30 Hz) + IMU (@200 Hz)
+  -> realsense_camera_node (fisheye auto-enabled when use_vins_odom:=true)
+  -> /t265/fisheye1/image_raw, /t265/fisheye2/image_raw, /t265/imu
+  -> [vins_node] (feature tracking via OpenCV, optional CUDA acceleration)
+  -> /vins/raw_odometry (t265_pose_frame)
+  -> [odom_tf_relay] (frame adaptation: t265_pose_frame -> ackermann/base_link)
+  -> /vins_odom (odom -> ackermann/base_link)
+  -> EKF (odom0, IMU yaw fusion disabled for external VIO)
+  -> /odometry/filtered -> RTAB-Map / Nav2 / PX4
+```
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/vins_fusion_bringup/launch/vins_fusion.launch.py` | Launch + relay wiring |
+| `src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml` | Estimator config |
+| `src/vins_fusion_bringup/config/left.yaml`, `right.yaml` | Kannala-Brandt fisheye calibration |
+| `patches/vins-fusion-ros2-jazzy.patch` | ROS 2 Jazzy compatibility patch |
+| `docker/install_vins_gpu_deps.sh` | CUDA OpenCV builder (per-arch cached) |
+| `scripts/build_vins_gpu.sh` | Two-phase colcon build (VINS core + bringup) |
+
+---
+
+## Docker GPU Setup
+
+### Architecture-Qualified OpenCV CUDA Cache
+
+The CUDA-enabled OpenCV build is cached per CPU architecture under
+`docker_cache/opencv-cuda/<arch>/<version>/` so that x86_64 and aarch64
+containers each maintain their own prebuilt binaries.  The cache is
+bind-mounted into the container at `/workspace/docker_cache/`.
+
+```
+docker_cache/opencv-cuda/
+  x86_64/
+    4.10.0/           # CUDA 12.8, sm_86 (desktop GPU)
+    current -> 4.10.0
+  aarch64/
+    4.5.5/            # CUDA 11.4, sm_72/87 (Jetson Xavier NX)
+    current -> 4.5.5
+```
+
+The architecture is detected at build/launch time via `uname -m` (shell) or
+`platform.machine()` (Python launch file).
+
+### x86_64 Desktop (CUDA 12.x)
+
+```bash
+# Inside the Docker container (ackermann_slam):
+# 1. Build CUDA OpenCV (one-time, cached)
+./docker/install_vins_gpu_deps.sh
+
+# 2. Build VINS packages against CUDA OpenCV
+./scripts/build_vins_gpu.sh
+
+# 3. Launch
+ros2 launch robot_bringup robot_bringup.launch.py \
+  use_gazebo:=false hw_enable_t265:=true use_vins_odom:=true \
+  depth_camera:=none rtabmap:=false nav2:=false rviz:=false
+```
+
+Prerequisites:
+- Host CUDA toolkit (12.x) mounted into container via `docker-compose.yml`
+  (auto-detected by `scripts/lib/dc.sh`)
+- NVIDIA GPU with compute capability >= 8.6
+
+### Jetson Xavier NX (CUDA 11.4)
+
+```bash
+# Inside the Docker container (jazzy_slam_aarch64):
+# 1. Build CUDA OpenCV 4.5.5 (one-time, ~45 min on Xavier NX)
+OPENCV_VERSION=4.5.5 ./docker/install_vins_gpu_deps.sh
+
+# 2. Build VINS packages
+OPENCV_VERSION=4.5.5 ./scripts/build_vins_gpu.sh
+
+# 3. Launch
+ros2 launch robot_bringup robot_bringup.launch.py \
+  use_gazebo:=false hw_enable_t265:=true use_vins_odom:=true \
+  depth_camera:=none rtabmap:=false nav2:=false rviz:=false
+```
+
+Prerequisites:
+- JetPack 5.x (L4T R35.4.1, CUDA 11.4)
+- Host CUDA toolkit at `/usr/local/cuda-11.4` mounted into container
+
+### Why OpenCV Versions Differ
+
+OpenCV's generated `OpenCVConfig.cmake` enforces an `EXACT` CUDA version
+match at CMake configure time.  A library built with CUDA 12.8 will reject
+CUDA 11.4 and vice versa.  Additionally, the `.so` binaries are
+architecture-specific (ELF x86-64 vs ARM aarch64) and cannot be cross-loaded.
+This is why the cache must be both architecture-qualified and built with the
+host's CUDA version.
+
+### LD_LIBRARY_PATH Isolation
+
+The CUDA OpenCV is not installed system-wide.  The launch file injects
+`LD_LIBRARY_PATH=<opencv_prefix>/lib` only for the `vins_node` process,
+avoiding conflicts with the system OpenCV (4.6.0 on Jazzy) used by RTAB-Map
+and cv_bridge.
+
+---
+
+## Compilation Procedure
+
+### Full Build (Fresh Setup)
+
+```bash
+# 1. Apply VINS-Fusion Jazzy compatibility patch
+./scripts/apply_vins_fusion_patch.sh
+
+# 2. Build CUDA OpenCV (skip if docker_cache/<arch>/current/ exists)
+./docker/install_vins_gpu_deps.sh          # x86_64
+OPENCV_VERSION=4.5.5 ./docker/install_vins_gpu_deps.sh  # Jetson
+
+# 3. Build VINS packages with GPU support
+./scripts/build_vins_gpu.sh
+```
+
+### Rebuild After Code Changes
+
+```bash
+# VINS source or config only (fast, ~1 min x86, ~10 min Jetson)
+./scripts/build_vins_gpu.sh
+
+# Force OpenCV rebuild (after CUDA update)
+FORCE_REBUILD=1 ./docker/install_vins_gpu_deps.sh
+```
+
+### Build Verification
+
+```bash
+# Check binary links correct CUDA OpenCV
+ldd install/vins/lib/vins/vins_node | grep opencv
+
+# Expected: libopencv_cuda*.so from docker_cache/<arch>/current/lib/
+# System OpenCV (4.6.0) from /lib/ is expected for cv_bridge deps
+```
+
+---
+
+## VIO Performance Comparison
+
+Unless noted otherwise, both platforms used the same tuned rover config from
+`src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml`:
+
+- `max_cnt: 80`
+- `min_dist: 25`
+- `freq: 20`
+- `show_track: 0`
+- `max_solver_time: 0.025`
+- `max_num_iterations: 4`
+- `use_gpu: 1`
+- `use_gpu_acc_flow: 1`
+- `use_gpu_ceres: 0`
+
+The x86_64 measurements were taken from message header timestamps over an 8 s
+window while the rover stayed stationary. This avoids the misleading
+`ros2 topic hz` spikes seen with the dual-fisheye T265 streams.
+
+### Test Platforms
+
+| Platform | Notes |
+|----------|-------|
+| x86_64 + RTX A2000 Laptop GPU | Docker container exposed 16 logical CPU threads and an NVIDIA RTX A2000 Laptop GPU |
+| Jetson Xavier NX | 6-core ARM Cortex-A57 @ 1.42 GHz, 384-core Volta GPU, 8 GB RAM |
+
+### Side-By-Side Summary
+
+| Metric | x86_64 tuned | Jetson tuned | Jetson stock |
+|--------|--------------|--------------|--------------|
+| T265 built-in odom | 198-200 Hz | 200 Hz | 200 Hz |
+| VINS raw/adapted odom | 26 Hz | 16 Hz | 8.5 Hz |
+| vins camera-pose output | 26 Hz | not separately sampled | not separately sampled |
+| vins IMU propagate debug stream | 200 Hz before publisher cleanup | not sampled | not sampled |
+| vins_node CPU | 50-73% of one host core | 126% | 176% |
+| realsense_camera_node CPU | 10-17% | 54% | 55% |
+| GPU utilization | 10-11% | 33-46% | 8-31% |
+| vins_node RAM | ~660 MB | ~680 MB | ~810 MB |
+| T265 built-in drift over 30 s | 0.0024 m | 0.004 m | 0.004 m |
+| VINS drift over 30 s | 0.0100 m | 0.016 m | 0.073 m |
+
+### x86_64 Measured Topic Rates
+
+| Topic | Measured Rate |
+|------|---------------|
+| `/t265/fisheye1/image_raw` | 30.001 Hz |
+| `/t265/fisheye2/image_raw` | 30.001 Hz |
+| `/t265/odom` | 198.152 Hz |
+| `/t265/odom_base` | 200.039 Hz |
+| `/vins/raw_odometry` | 26.000 Hz |
+| `/vins_odom` | 26.000 Hz |
+| `/vins/camera_pose` | 26.000 Hz |
+| `/vins/imu_propagate` | 200.039 Hz before publisher cleanup |
+
+### Interpretation
+
+- The T265 built-in VIO remains the highest-rate source on both platforms and
+  stays near the device-native 200 Hz output.
+- On Jetson Xavier NX, the tuned VINS profile is usable but still clearly
+  compute-limited compared with the T265's built-in VPU pipeline.
+- On x86_64, the same tuned VINS profile reaches 26 Hz with substantially more
+  CPU and GPU headroom than Jetson, which makes loop-closure-driven workflows
+  much more practical.
+- Even on x86_64, the T265 built-in odometry still wins on both rate and
+  stationary drift. VINS-Fusion remains the better choice when custom
+  calibration, estimator internals, or later loop/global fusion stages matter.
+
+### Tuned Config Parameters
+
+| Parameter | Stock | Tuned | Effect |
+|-----------|-------|-------|--------|
+| `max_cnt` | 150 | 80 | Fewer features tracked per frame |
+| `min_dist` | 30 | 25 | Tighter spacing, maintains coverage |
+| `freq` | 20 | 20 | Target publish rate |
+| `show_track` | 1 | 0 | Disables debug image rendering |
+| `max_solver_time` | 0.04 s | 0.025 s | Tighter Ceres solver deadline |
+| `max_num_iterations` | 8 | 4 | Fewer optimization iterations |
+| `use_gpu` | 1 | 1 | CUDA feature tracking (marginal benefit on Xavier) |
+| `use_gpu_acc_flow` | 1 | 1 | CUDA optical flow |
+| `use_gpu_ceres` | 0 | 0 | CPU solver (more numerically stable) |
+
+### Platform-Specific CPU / GPU Usage
+
+| Metric | Stock | Tuned | T265 Only |
+|--------|-------|-------|-----------|
+| vins_node CPU | 176% | 126% | N/A |
+| realsense_camera_node CPU | 55% | 54% | 55% |
+| System CPU avg (6 cores) | 57% | 43% | ~20% |
+| GPU (GR3D) | 8-31% | 33-46% | 0% |
+| RAM (vins_node) | 810 MB | 680 MB | N/A |
+| Total RAM | 2.9 GB | 2.8 GB | ~2.1 GB |
+
+### Jetson Stationary Drift (Origin-Subtracted)
+
+| Source | X (m) | Y (m) | Z (m) | Total (m) |
+|--------|-------|-------|-------|-----------|
+| T265 built-in | 0.000 | 0.003 | -0.002 | 0.004 |
+| VINS (stock) | -0.058 | -0.031 | 0.031 | 0.073 |
+| VINS (tuned) | -0.008 | -0.011 | 0.008 | 0.016 |
+
+### Recommendation
+
+For Jetson Xavier NX deployment, the T265 built-in VIO remains the preferred
+odometry source due to 200 Hz rate, sub-5mm stationary drift, and near-zero
+CPU overhead (processing runs on the T265's internal VPU). On x86_64,
+VINS-Fusion is viable at 26 Hz with low enough GPU overhead to be practical,
+but it still does not outperform the T265's built-in odometry on raw tracking
+rate or stationary drift. VINS-Fusion is most useful when:
+
+- The T265 built-in odometry is unreliable (poor lighting, high vibration)
+- Custom camera calibration or extrinsics are needed
+- Loop closure or map-aware relocalization is required (via loop_fusion)
+- The platform has more CPU/GPU headroom (x86 desktop, Orin)

--- a/patches/vins-fusion-ros2-jazzy.patch
+++ b/patches/vins-fusion-ros2-jazzy.patch
@@ -75,8 +75,160 @@ index 480f51a..6b204f5 100755
      }
  }
  
+diff --git a/loop_fusion/CMakeLists.txt b/loop_fusion/CMakeLists.txt
+index aff3409..e29f5b5 100755
+--- a/loop_fusion/CMakeLists.txt
++++ b/loop_fusion/CMakeLists.txt
+@@ -16,7 +16,7 @@ find_package(nav_msgs REQUIRED)
+ find_package(cv_bridge REQUIRED)
+ find_package(camera_models REQUIRED)
+ 
+-find_package(OpenCV)
++find_package(OpenCV REQUIRED)
+ find_package(Ceres REQUIRED)
+ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+ find_package(Eigen3)
+@@ -43,7 +43,7 @@ add_executable(loop_fusion_node
+ 
+     
+ # added from DEBUG
+-ament_target_dependencies(loop_fusion_node camera_models rclcpp ament_index_cpp std_msgs sensor_msgs visualization_msgs nav_msgs cv_bridge OpenCV) # roslib) # does 'roslib' really need ??
++ament_target_dependencies(loop_fusion_node camera_models rclcpp ament_index_cpp std_msgs sensor_msgs visualization_msgs nav_msgs cv_bridge) # roslib) # does 'roslib' really need ??
+ 
+ target_link_libraries(loop_fusion_node ${OpenCV_LIBS} ${CERES_LIBRARIES} ) #${catkin_LIBRARIES}  )
+ 
+diff --git a/loop_fusion/src/parameters.h b/loop_fusion/src/parameters.h
+index ba661f7..77a4e1f 100755
+--- a/loop_fusion/src/parameters.h
++++ b/loop_fusion/src/parameters.h
+@@ -20,7 +20,7 @@
+ #include <sensor_msgs/msg/point_cloud.hpp>
+ // #include <sensor_msgs/image_encodings.h>
+ #include "image_encodings.hpp"
+-#include <cv_bridge/cv_bridge.h>
++#include <cv_bridge/cv_bridge.hpp>
+ 
+ extern camodocal::CameraPtr m_camera;
+ extern Eigen::Vector3d tic;
+@@ -35,4 +35,3 @@ extern int COL;
+ extern std::string VINS_RESULT_PATH;
+ extern int DEBUG_IMAGE;
+ 
+-
+diff --git a/loop_fusion/src/pose_graph.h b/loop_fusion/src/pose_graph.h
+index 93b2137..8417847 100755
+--- a/loop_fusion/src/pose_graph.h
++++ b/loop_fusion/src/pose_graph.h
+@@ -21,8 +21,8 @@
+ #include <queue>
+ #include <assert.h>
+ #include <nav_msgs/msg/path.hpp>
+-#include <geometry_msgs/msg/point_stamped.h>
+-#include <nav_msgs/msg/odometry.h>
++#include <geometry_msgs/msg/point_stamped.hpp>
++#include <nav_msgs/msg/odometry.hpp>
+ #include <stdio.h>
+ #include <rclcpp/rclcpp.hpp>
+ #include "keyframe.h"
+@@ -337,4 +337,4 @@ struct RelativeRTError
+ 	double q_w, q_x, q_y, q_z;
+ 	double t_var, q_var;
+ 
+-};
+\ No newline at end of file
++};
+diff --git a/loop_fusion/src/pose_graph_node.cpp b/loop_fusion/src/pose_graph_node.cpp
+index 152d045..3ff4be9 100755
+--- a/loop_fusion/src/pose_graph_node.cpp
++++ b/loop_fusion/src/pose_graph_node.cpp
+@@ -19,7 +19,7 @@
+ #include "image_encodings.hpp"
+ #include <visualization_msgs/msg/marker.hpp>
+ #include <std_msgs/msg/bool.hpp>
+-#include <cv_bridge/cv_bridge.h>
++#include <cv_bridge/cv_bridge.hpp>
+ #include <iostream>
+ // #include <ros/package.h>
+ #include <ament_index_cpp/get_package_share_directory.hpp>
+diff --git a/loop_fusion/src/utility/CameraPoseVisualization.h b/loop_fusion/src/utility/CameraPoseVisualization.h
+index dbfae11..ef8164b 100755
+--- a/loop_fusion/src/utility/CameraPoseVisualization.h
++++ b/loop_fusion/src/utility/CameraPoseVisualization.h
+@@ -10,7 +10,7 @@
+ #pragma once
+ 
+ #include <rclcpp/rclcpp.hpp>
+-#include <std_msgs/msg/color_rgba.h>
++#include <std_msgs/msg/color_rgba.hpp>
+ #include <visualization_msgs/msg/marker.hpp>
+ #include <visualization_msgs/msg/marker_array.hpp>
+ #include <Eigen/Dense>
+diff --git a/vins/CMakeLists.txt b/vins/CMakeLists.txt
+index bcc560f..729c6f9 100755
+--- a/vins/CMakeLists.txt
++++ b/vins/CMakeLists.txt
+@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
+ add_compile_options(-Wextra -Wpedantic)
+ 
+ set(CMAKE_BUILD_TYPE Release)
++option(VINS_GPU_MODE "Enable CUDA-based feature tracking in vins" OFF)
+ 
+ # find dependencies
+ find_package(ament_cmake REQUIRED)
+@@ -19,6 +20,7 @@ find_package(tf2_ros REQUIRED)
+ find_package(cv_bridge REQUIRED)
+ find_package(camera_models REQUIRED)
+ find_package(image_transport REQUIRED)
++find_package(message_filters REQUIRED)
+ 
+ 
+ find_package(OpenCV REQUIRED)
+@@ -54,11 +56,17 @@ add_library(vins_lib
+     src/initial/initial_ex_rotation.cpp
+     src/featureTracker/feature_tracker.cpp)
+ target_link_libraries(vins_lib  ${OpenCV_LIBS} ${CERES_LIBRARIES})
++if(VINS_GPU_MODE)
++  target_compile_definitions(vins_lib PRIVATE GPU_MODE)
++  message(STATUS "vins GPU feature tracking enabled")
++else()
++  message(STATUS "vins GPU feature tracking disabled")
++endif()
+ 
+ ament_target_dependencies(vins_lib rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport)
+ 
+ add_executable(vins_node src/rosNodeTest.cpp)
+-ament_target_dependencies(vins_node rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport)
++ament_target_dependencies(vins_node rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport message_filters)
+ target_link_libraries(vins_node vins_lib) 
+ 
+ add_executable(kitti_odom_test src/KITTIOdomTest.cpp)
+diff --git a/vins/package.xml b/vins/package.xml
+index b79c04c..08b0e25 100755
+--- a/vins/package.xml
++++ b/vins/package.xml
+@@ -20,6 +20,7 @@
+   <depend>cv_bridge</depend>
+   <depend>camera_models</depend>
+   <depend>image_transport</depend>
++  <depend>message_filters</depend>
+ 
+   <test_depend>ament_lint_auto</test_depend>
+   <test_depend>ament_lint_common</test_depend>
+diff --git a/vins/src/KITTIOdomTest.cpp b/vins/src/KITTIOdomTest.cpp
+index d5ae538..d625bde 100755
+--- a/vins/src/KITTIOdomTest.cpp
++++ b/vins/src/KITTIOdomTest.cpp
+@@ -16,7 +16,7 @@
+ #include <string>
+ #include <rclcpp/rclcpp.hpp>
+ #include <sensor_msgs/msg/image.hpp>
+-#include <cv_bridge/cv_bridge.h>
++#include <cv_bridge/cv_bridge.hpp>
+ #include "estimator/estimator.h"
+ #include "utility/visualization.h"
+ 
 diff --git a/vins/src/estimator/estimator.cpp b/vins/src/estimator/estimator.cpp
-index e606bb7..5d54f2d 100755
+index 45d90c7..5d54f2d 100755
 --- a/vins/src/estimator/estimator.cpp
 +++ b/vins/src/estimator/estimator.cpp
 @@ -174,14 +174,7 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
@@ -102,6 +254,15 @@ index e606bb7..5d54f2d 100755
          mPropagate.unlock();
      }
  }
+@@ -348,7 +340,7 @@ void Estimator::processMeasurements()
+             printStatistics(*this, 0);
+ 
+             std_msgs::msg::Header header;
+-            header.frame_id = "world";
++            header.frame_id = ODOM_FRAME;
+ 
+             int sec_ts = (int)feature.first;
+             uint nsec_ts = (uint)((feature.first - sec_ts) * 1e9);
 @@ -356,17 +348,9 @@ void Estimator::processMeasurements()
              header.stamp.nanosec = nsec_ts;
  
@@ -176,6 +337,21 @@ index e606bb7..5d54f2d 100755
  
      double2vector();
      //printf("frame_count: %d \n", frame_count);
+diff --git a/vins/src/estimator/estimator.h b/vins/src/estimator/estimator.h
+index bf27b8c..f025c4a 100755
+--- a/vins/src/estimator/estimator.h
++++ b/vins/src/estimator/estimator.h
+@@ -11,8 +11,8 @@
+  
+ #include <thread>
+ #include <mutex>
+-#include <std_msgs/msg/header.h>
+-#include <std_msgs/msg/float32.h>
++#include <std_msgs/msg/header.hpp>
++#include <std_msgs/msg/float32.hpp>
+ #include <ceres/ceres.h>
+ #include <unordered_map>
+ #include <queue>
 diff --git a/vins/src/estimator/feature_manager.cpp b/vins/src/estimator/feature_manager.cpp
 index d6022a4..e7bd4d1 100755
 --- a/vins/src/estimator/feature_manager.cpp
@@ -190,8 +366,62 @@ index d6022a4..e7bd4d1 100755
          {
              it_per_id.solve_flag = 2;
          }
+diff --git a/vins/src/estimator/parameters.cpp b/vins/src/estimator/parameters.cpp
+index 82992e9..b2562f3 100755
+--- a/vins/src/estimator/parameters.cpp
++++ b/vins/src/estimator/parameters.cpp
+@@ -34,6 +34,8 @@ std::string EX_CALIB_RESULT_PATH;
+ std::string VINS_RESULT_PATH;
+ std::string OUTPUT_FOLDER;
+ std::string IMU_TOPIC;
++std::string ODOM_FRAME;
++std::string BODY_FRAME;
+ int ROW, COL;
+ double TD;
+ int NUM_OF_CAM;
+@@ -97,6 +99,14 @@ void readParameters(std::string config_file)
+     USE_GPU = fsSettings["use_gpu"];
+     USE_GPU_ACC_FLOW = fsSettings["use_gpu_acc_flow"];
+     USE_GPU_CERES = fsSettings["use_gpu_ceres"];
++#ifndef GPU_MODE
++    if (USE_GPU || USE_GPU_ACC_FLOW)
++    {
++        ROS_WARN("GPU tracking requested in config, but vins was built without VINS_GPU_MODE. Falling back to CPU tracking.");
++        USE_GPU = 0;
++        USE_GPU_ACC_FLOW = 0;
++    }
++#endif
+ 
+     USE_IMU = fsSettings["imu"];
+     printf("USE_IMU: %d\n", USE_IMU);
+@@ -117,6 +127,8 @@ void readParameters(std::string config_file)
+     MIN_PARALLAX = MIN_PARALLAX / FOCAL_LENGTH;
+ 
+     fsSettings["output_path"] >> OUTPUT_FOLDER;
++    if (OUTPUT_FOLDER.empty())
++        OUTPUT_FOLDER = "/tmp";
+     VINS_RESULT_PATH = OUTPUT_FOLDER + "/vio.csv";
+     std::cout << "result path " << VINS_RESULT_PATH << std::endl;
+     std::ofstream fout(VINS_RESULT_PATH, std::ios::out);
+@@ -198,6 +210,16 @@ void readParameters(std::string config_file)
+     COL = fsSettings["image_width"];
+     ROS_INFO("ROW: %d COL: %d ", ROW, COL);
+ 
++    if (!fsSettings["odom_frame"].isNone())
++        fsSettings["odom_frame"] >> ODOM_FRAME;
++    else
++        ODOM_FRAME = "world";
++
++    if (!fsSettings["body_frame"].isNone())
++        fsSettings["body_frame"] >> BODY_FRAME;
++    else
++        BODY_FRAME = "body";
++
+     if(!USE_IMU)
+     {
+         ESTIMATE_EXTRINSIC = 0;
 diff --git a/vins/src/estimator/parameters.h b/vins/src/estimator/parameters.h
-index bdd505b..fb6dc83 100755
+index 50ba1af..fb6dc83 100755
 --- a/vins/src/estimator/parameters.h
 +++ b/vins/src/estimator/parameters.h
 @@ -27,7 +27,7 @@ using namespace std;
@@ -203,6 +433,15 @@ index bdd505b..fb6dc83 100755
  
  extern double INIT_DEPTH;
  extern double MIN_PARALLAX;
+@@ -52,6 +52,8 @@ extern std::string EX_CALIB_RESULT_PATH;
+ extern std::string VINS_RESULT_PATH;
+ extern std::string OUTPUT_FOLDER;
+ extern std::string IMU_TOPIC;
++extern std::string ODOM_FRAME;
++extern std::string BODY_FRAME;
+ extern double TD;
+ extern int ESTIMATE_TD;
+ extern int ROLLING_SHUTTER;
 diff --git a/vins/src/factor/projectionOneFrameTwoCamFactor.cpp b/vins/src/factor/projectionOneFrameTwoCamFactor.cpp
 index 8e24cfa..492b2ed 100755
 --- a/vins/src/factor/projectionOneFrameTwoCamFactor.cpp
@@ -523,8 +762,168 @@ index 3508bc0..8153ff3 100755
              }
              else
                  pts_velocity.push_back(cv::Point2f(0, 0));
+diff --git a/vins/src/rosNodeTest.cpp b/vins/src/rosNodeTest.cpp
+index 37bd75c..5267f6a 100755
+--- a/vins/src/rosNodeTest.cpp
++++ b/vins/src/rosNodeTest.cpp
+@@ -13,10 +13,14 @@
+ #include <queue>
+ #include <map>
+ #include <thread>
++#include <atomic>
+ #include <mutex>
+ #include <rclcpp/rclcpp.hpp>
+-#include <cv_bridge/cv_bridge.h>
++#include <cv_bridge/cv_bridge.hpp>
+ #include <opencv2/opencv.hpp>
++#include <message_filters/subscriber.h>
++#include <message_filters/synchronizer.h>
++#include <message_filters/sync_policies/approximate_time.h>
+ #include "estimator/estimator.h"
+ #include "estimator/parameters.h"
+ #include "utility/visualization.h"
+@@ -28,6 +32,7 @@ queue<sensor_msgs::msg::PointCloud::ConstPtr> feature_buf;
+ queue<sensor_msgs::msg::Image::ConstPtr> img0_buf;
+ queue<sensor_msgs::msg::Image::ConstPtr> img1_buf;
+ std::mutex m_buf;
++std::atomic<bool> sync_running{true};
+ 
+ // header: 1403715278
+ void img0_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
+@@ -38,11 +43,16 @@ void img0_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
+     m_buf.unlock();
+ }
+ 
+-void img1_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
++// Stereo synchronized callback: called by message_filters when both images
++// arrive with matching timestamps. Pushes them to the queues atomically so
++// sync_process always finds a ready matched pair (no timestamp comparison needed).
++void stereo_img_callback(
++    const sensor_msgs::msg::Image::ConstSharedPtr& img0_msg,
++    const sensor_msgs::msg::Image::ConstSharedPtr& img1_msg)
+ {
+     m_buf.lock();
+-    // std::cout << "Right: " << img_msg->header.stamp.sec << "." << img_msg->header.stamp.nanosec << endl;
+-    img1_buf.push(img_msg);
++    img0_buf.push(img0_msg);
++    img1_buf.push(img1_msg);
+     m_buf.unlock();
+ }
+ 
+@@ -73,7 +83,7 @@ cv::Mat getImageFromMsg(const sensor_msgs::msg::Image::ConstPtr &img_msg)
+ // extract images with same timestamp from two topics
+ void sync_process()
+ {
+-    while(1)
++    while(sync_running.load())
+     {
+         if(STEREO)
+         {
+@@ -83,34 +93,19 @@ void sync_process()
+             m_buf.lock();
+             if (!img0_buf.empty() && !img1_buf.empty())
+             {
+-                double time0 = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
+-                double time1 = img1_buf.front()->header.stamp.sec + img1_buf.front()->header.stamp.nanosec * (1e-9);
+-
+-                // 0.003s sync tolerance
+-                if(time0 < time1 - 0.003)
+-                {
+-                    img0_buf.pop();
+-                    printf("throw img0\n");
+-                }
+-                else if(time0 > time1 + 0.003)
+-                {
+-                    img1_buf.pop();
+-                    printf("throw img1\n");
+-                }
+-                else
++                // Images are pre-synchronized by message_filters::ApproximateTime;
++                // no timestamp comparison needed here.
++                time = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
++                header = img0_buf.front()->header;
++                image0 = getImageFromMsg(img0_buf.front());
++                img0_buf.pop();
++                image1 = getImageFromMsg(img1_buf.front());
++                img1_buf.pop();
++                // Drop old buffered frames to keep up with real-time
++                while(img0_buf.size() > 1 && img1_buf.size() > 1)
+                 {
+-                    time = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
+-                    header = img0_buf.front()->header;
+-                    image0 = getImageFromMsg(img0_buf.front());
+                     img0_buf.pop();
+-                    image1 = getImageFromMsg(img1_buf.front());
+                     img1_buf.pop();
+-                    // Drop old buffered frames to keep up with real-time
+-                    while(img0_buf.size() > 1 && img1_buf.size() > 1)
+-                    {
+-                        img0_buf.pop();
+-                        img1_buf.pop();
+-                    }
+                 }
+             }
+             m_buf.unlock();
+@@ -279,12 +274,29 @@ int main(int argc, char **argv)
+         sub_imu = n->create_subscription<sensor_msgs::msg::Imu>(IMU_TOPIC, rclcpp::SensorDataQoS().keep_last(2000), imu_callback);
+     }
+     auto sub_feature = n->create_subscription<sensor_msgs::msg::PointCloud>("/feature_tracker/feature", rclcpp::QoS(rclcpp::KeepLast(2000)), feature_callback);
+-    auto sub_img0 = n->create_subscription<sensor_msgs::msg::Image>(IMAGE0_TOPIC, rclcpp::SensorDataQoS(), img0_callback);
++    // For stereo: use message_filters::ApproximateTimeSynchronizer so both
++    // fisheye images are always delivered as a matched pair regardless of DDS
++    // subscription jitter. For mono: use a plain subscription.
++    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_img0_mono;
++    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> sub_img0_sync, sub_img1_sync;
++    using SyncPolicy = message_filters::sync_policies::ApproximateTime<
++        sensor_msgs::msg::Image, sensor_msgs::msg::Image>;
++    std::shared_ptr<message_filters::Synchronizer<SyncPolicy>> stereo_sync;
+ 
+-    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_img1 = NULL;
+     if(STEREO)
+     {
+-        sub_img1 = n->create_subscription<sensor_msgs::msg::Image>(IMAGE1_TOPIC, rclcpp::SensorDataQoS(), img1_callback);
++        sub_img0_sync = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
++            n, IMAGE0_TOPIC, rmw_qos_profile_sensor_data);
++        sub_img1_sync = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
++            n, IMAGE1_TOPIC, rmw_qos_profile_sensor_data);
++        stereo_sync = std::make_shared<message_filters::Synchronizer<SyncPolicy>>(
++            SyncPolicy(10), *sub_img0_sync, *sub_img1_sync);
++        stereo_sync->registerCallback(stereo_img_callback);
++    }
++    else
++    {
++        sub_img0_mono = n->create_subscription<sensor_msgs::msg::Image>(
++            IMAGE0_TOPIC, rclcpp::SensorDataQoS(), img0_callback);
+     }
+ 
+     auto sub_restart = n->create_subscription<std_msgs::msg::Bool>("/vins_restart", rclcpp::QoS(rclcpp::KeepLast(100)), restart_callback);
+@@ -292,9 +304,11 @@ int main(int argc, char **argv)
+     auto sub_cam_switch = n->create_subscription<std_msgs::msg::Bool>("/vins_cam_switch", rclcpp::QoS(rclcpp::KeepLast(100)), cam_switch_callback);
+ 
+     std::thread sync_thread{sync_process};
++    sync_thread.detach();
+     rclcpp::executors::MultiThreadedExecutor executor;
+     executor.add_node(n);
+     executor.spin();
++    sync_running.store(false);
+ 
+     return 0;
+ }
+diff --git a/vins/src/utility/CameraPoseVisualization.h b/vins/src/utility/CameraPoseVisualization.h
+index f6a3a71..b0b1bb5 100755
+--- a/vins/src/utility/CameraPoseVisualization.h
++++ b/vins/src/utility/CameraPoseVisualization.h
+@@ -10,7 +10,7 @@
+ #pragma once
+ 
+ #include <rclcpp/rclcpp.hpp>
+-#include <std_msgs/msg/color_rgba.h>
++#include <std_msgs/msg/color_rgba.hpp>
+ #include <visualization_msgs/msg/marker.hpp>
+ #include <visualization_msgs/msg/marker_array.hpp>
+ #include <Eigen/Dense>
 diff --git a/vins/src/utility/visualization.cpp b/vins/src/utility/visualization.cpp
-index df53026..9121de3 100755
+index 98422b2..9121de3 100755
 --- a/vins/src/utility/visualization.cpp
 +++ b/vins/src/utility/visualization.cpp
 @@ -11,21 +11,13 @@
@@ -551,7 +950,7 @@ index df53026..9121de3 100755
  static double sum_of_path = 0;
  static Vector3d last_path(0.0, 0.0, 0.0);
  
-@@ -33,60 +25,11 @@ size_t pub_counter = 0;
+@@ -33,59 +25,11 @@ size_t pub_counter = 0;
  
  void registerPub(rclcpp::Node::SharedPtr n)
  {
@@ -581,8 +980,7 @@ index df53026..9121de3 100755
 -    odometry.header.stamp.sec = sec_ts;
 -    odometry.header.stamp.nanosec = nsec_ts;
 -
--    odometry.header.frame_id = ODOM_FRAME;
--    odometry.child_frame_id = BODY_FRAME;
+-    odometry.header.frame_id = "world";
 -    odometry.pose.pose.position.x = P.x();
 -    odometry.pose.pose.position.y = P.y();
 -    odometry.pose.pose.position.z = P.z();
@@ -599,7 +997,7 @@ index df53026..9121de3 100755
 -void pubTrackImage(const cv::Mat &imgTrack, const double t)
 -{
 -    std_msgs::msg::Header header;
--    header.frame_id = ODOM_FRAME;
+-    header.frame_id = "world";
 -
 -    int sec_ts = (int)t;
 -    uint nsec_ts = (uint)((t - sec_ts) * 1e9);
@@ -612,23 +1010,34 @@ index df53026..9121de3 100755
  }
  
  
-@@ -155,15 +98,6 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
+@@ -138,8 +82,8 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
+     {
+         nav_msgs::msg::Odometry odometry;
+         odometry.header = header;
+-        odometry.header.frame_id = "world";
+-        odometry.child_frame_id = "world";
++        odometry.header.frame_id = ODOM_FRAME;
++        odometry.child_frame_id = BODY_FRAME;
+         Quaterniond tmp_Q;
+         tmp_Q = Quaterniond(estimator.Rs[WINDOW_SIZE]);
+         odometry.pose.pose.position.x = estimator.Ps[WINDOW_SIZE].x();
+@@ -154,15 +98,6 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
          odometry.twist.twist.linear.z = estimator.Vs[WINDOW_SIZE].z();
          pub_odometry->publish(odometry);
  
 -        geometry_msgs::msg::PoseStamped pose_stamped;
 -        pose_stamped.header = header;
--        pose_stamped.header.frame_id = ODOM_FRAME;
+-        pose_stamped.header.frame_id = "world";
 -        pose_stamped.pose = odometry.pose.pose;
 -        path.header = header;
--        path.header.frame_id = ODOM_FRAME;
+-        path.header.frame_id = "world";
 -        path.poses.push_back(pose_stamped);
 -        pub_path->publish(path);
 -
          // write result to file
          ofstream foutC(VINS_RESULT_PATH, ios::app);
          foutC.setf(ios::fixed, ios::floatfield);
-@@ -182,112 +116,16 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
+@@ -181,111 +116,16 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
                << estimator.Vs[WINDOW_SIZE].z() << "," << endl;
          foutC.close();
          Eigen::Vector3d tmp_T = estimator.Ps[WINDOW_SIZE];
@@ -645,7 +1054,7 @@ index df53026..9121de3 100755
 -        return;
 -    visualization_msgs::msg::Marker key_poses;
 -    key_poses.header = header;
--    key_poses.header.frame_id = ODOM_FRAME;
+-    key_poses.header.frame_id = "world";
 -    key_poses.ns = "key_poses";
 -    key_poses.type = visualization_msgs::msg::Marker::SPHERE_LIST;
 -    key_poses.action = visualization_msgs::msg::Marker::ADD;
@@ -685,8 +1094,7 @@ index df53026..9121de3 100755
 -
 -        nav_msgs::msg::Odometry odometry;
 -        odometry.header = header;
--        odometry.header.frame_id = ODOM_FRAME;
--        odometry.child_frame_id = BODY_FRAME;
+-        odometry.header.frame_id = "world";
 -        odometry.pose.pose.position.x = P.x();
 -        odometry.pose.pose.position.y = P.y();
 -        odometry.pose.pose.position.z = P.z();
@@ -743,7 +1151,7 @@ index df53026..9121de3 100755
      sensor_msgs::msg::PointCloud margin_cloud;
      margin_cloud.header = header;
  
-@@ -324,7 +162,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+@@ -322,7 +162,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      return; // tmp.
  
  
@@ -751,7 +1159,7 @@ index df53026..9121de3 100755
      if( estimator.solver_flag != Estimator::SolverFlag::NON_LINEAR)
          return;
  
-@@ -335,17 +172,15 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+@@ -333,30 +172,25 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      // body frame
      Vector3d correct_t;
      Quaterniond correct_q;
@@ -773,7 +1181,12 @@ index df53026..9121de3 100755
  
  
      // transform.header.stamp = header.stamp;
-@@ -356,9 +191,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+-    transform.header.frame_id = "world";
+-    transform.child_frame_id = "body";
++    transform.header.frame_id = ODOM_FRAME;
++    transform.child_frame_id = BODY_FRAME;
+ 
+     transform.transform.translation.x = correct_t(0);
      transform.transform.translation.y = correct_t(1);
      transform.transform.translation.z = correct_t(2);
  
@@ -783,7 +1196,7 @@ index df53026..9121de3 100755
      q.setW(correct_q.w());
      q.setX(correct_q.x());
      q.setY(correct_q.y());
-@@ -368,15 +200,8 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+@@ -366,18 +200,11 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      transform.transform.rotation.z = q.z();
      transform.transform.rotation.w = q.w();
  
@@ -798,8 +1211,12 @@ index df53026..9121de3 100755
 -
      // camera frame
      transform_cam.header.stamp = header.stamp;
-     transform_cam.header.frame_id = BODY_FRAME;
-@@ -399,9 +224,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+-    transform_cam.header.frame_id = "body";
++    transform_cam.header.frame_id = BODY_FRAME;
+     transform_cam.child_frame_id = "camera";
+ 
+ 
+@@ -397,12 +224,9 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
  
      // br->sendTransform(transform_cam);
  
@@ -808,8 +1225,12 @@ index df53026..9121de3 100755
 -    
      nav_msgs::msg::Odometry odometry;
      odometry.header = header;
-     odometry.header.frame_id = ODOM_FRAME;
-@@ -414,9 +236,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+-    odometry.header.frame_id = "world";
++    odometry.header.frame_id = ODOM_FRAME;
+     odometry.pose.pose.position.x = estimator.tic[0].x();
+     odometry.pose.pose.position.y = estimator.tic[0].y();
+     odometry.pose.pose.position.z = estimator.tic[0].z();
+@@ -412,9 +236,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      odometry.pose.pose.orientation.z = tmp_q.z();
      odometry.pose.pose.orientation.w = tmp_q.w();
  
@@ -819,10 +1240,48 @@ index df53026..9121de3 100755
  
  }
  
+@@ -488,7 +310,7 @@ void pubKeyframe(const Estimator &estimator)
+         odometry.header.stamp.sec = sec_ts;
+         odometry.header.stamp.nanosec = nsec_ts;
+ 
+-        odometry.header.frame_id = "world";
++        odometry.header.frame_id = ODOM_FRAME;
+         odometry.pose.pose.position.x = P.x();
+         odometry.pose.pose.position.y = P.y();
+         odometry.pose.pose.position.z = P.z();
+@@ -508,7 +330,7 @@ void pubKeyframe(const Estimator &estimator)
+         point_cloud.header.stamp.sec = sec_ts;
+         point_cloud.header.stamp.nanosec = nsec_ts;
+ 
+-        point_cloud.header.frame_id = "world";
++        point_cloud.header.frame_id = ODOM_FRAME;
+         for (auto &it_per_id : estimator.f_manager.feature)
+         {
+             int frame_size = it_per_id.feature_per_frame.size();
+@@ -538,4 +360,4 @@ void pubKeyframe(const Estimator &estimator)
+         }
+         pub_keyframe_point->publish(point_cloud);
+     }
+-}
+\ No newline at end of file
++}
 diff --git a/vins/src/utility/visualization.h b/vins/src/utility/visualization.h
-index 6a13585..d5914f5 100755
+index ab31748..d5914f5 100755
 --- a/vins/src/utility/visualization.h
 +++ b/vins/src/utility/visualization.h
+@@ -18,10 +18,10 @@
+ #include <sensor_msgs/msg/image.hpp>
+ // #include <sensor_msgs/image_encodings.h>
+ #include "image_encodings.hpp"
+-#include <cv_bridge/cv_bridge.h>
++#include <cv_bridge/cv_bridge.hpp>
+ #include <nav_msgs/msg/path.hpp>
+ #include <nav_msgs/msg/odometry.hpp>
+-#include <geometry_msgs/msg/point_stamped.h>
++#include <geometry_msgs/msg/point_stamped.hpp>
+ #include <visualization_msgs/msg/marker.hpp>
+ #include <tf2_ros/transform_broadcaster.h>
+ #include <tf2/LinearMath/Quaternion.h>
 @@ -33,31 +33,17 @@
  #include <fstream>
  

--- a/patches/vins-fusion-ros2-jazzy.patch
+++ b/patches/vins-fusion-ros2-jazzy.patch
@@ -75,180 +75,52 @@ index 480f51a..6b204f5 100755
      }
  }
  
-diff --git a/loop_fusion/CMakeLists.txt b/loop_fusion/CMakeLists.txt
-index aff3409..e29f5b5 100755
---- a/loop_fusion/CMakeLists.txt
-+++ b/loop_fusion/CMakeLists.txt
-@@ -16,7 +16,7 @@ find_package(nav_msgs REQUIRED)
- find_package(cv_bridge REQUIRED)
- find_package(camera_models REQUIRED)
- 
--find_package(OpenCV)
-+find_package(OpenCV REQUIRED)
- find_package(Ceres REQUIRED)
- set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
- find_package(Eigen3)
-@@ -43,7 +43,7 @@ add_executable(loop_fusion_node
- 
-     
- # added from DEBUG
--ament_target_dependencies(loop_fusion_node camera_models rclcpp ament_index_cpp std_msgs sensor_msgs visualization_msgs nav_msgs cv_bridge OpenCV) # roslib) # does 'roslib' really need ??
-+ament_target_dependencies(loop_fusion_node camera_models rclcpp ament_index_cpp std_msgs sensor_msgs visualization_msgs nav_msgs cv_bridge) # roslib) # does 'roslib' really need ??
- 
- target_link_libraries(loop_fusion_node ${OpenCV_LIBS} ${CERES_LIBRARIES} ) #${catkin_LIBRARIES}  )
- 
-diff --git a/loop_fusion/src/parameters.h b/loop_fusion/src/parameters.h
-index ba661f7..77a4e1f 100755
---- a/loop_fusion/src/parameters.h
-+++ b/loop_fusion/src/parameters.h
-@@ -20,7 +20,7 @@
- #include <sensor_msgs/msg/point_cloud.hpp>
- // #include <sensor_msgs/image_encodings.h>
- #include "image_encodings.hpp"
--#include <cv_bridge/cv_bridge.h>
-+#include <cv_bridge/cv_bridge.hpp>
- 
- extern camodocal::CameraPtr m_camera;
- extern Eigen::Vector3d tic;
-@@ -35,4 +35,3 @@ extern int COL;
- extern std::string VINS_RESULT_PATH;
- extern int DEBUG_IMAGE;
- 
--
-diff --git a/loop_fusion/src/pose_graph.h b/loop_fusion/src/pose_graph.h
-index 93b2137..8417847 100755
---- a/loop_fusion/src/pose_graph.h
-+++ b/loop_fusion/src/pose_graph.h
-@@ -21,8 +21,8 @@
- #include <queue>
- #include <assert.h>
- #include <nav_msgs/msg/path.hpp>
--#include <geometry_msgs/msg/point_stamped.h>
--#include <nav_msgs/msg/odometry.h>
-+#include <geometry_msgs/msg/point_stamped.hpp>
-+#include <nav_msgs/msg/odometry.hpp>
- #include <stdio.h>
- #include <rclcpp/rclcpp.hpp>
- #include "keyframe.h"
-@@ -337,4 +337,4 @@ struct RelativeRTError
- 	double q_w, q_x, q_y, q_z;
- 	double t_var, q_var;
- 
--};
-\ No newline at end of file
-+};
-diff --git a/loop_fusion/src/pose_graph_node.cpp b/loop_fusion/src/pose_graph_node.cpp
-index 152d045..3ff4be9 100755
---- a/loop_fusion/src/pose_graph_node.cpp
-+++ b/loop_fusion/src/pose_graph_node.cpp
-@@ -19,7 +19,7 @@
- #include "image_encodings.hpp"
- #include <visualization_msgs/msg/marker.hpp>
- #include <std_msgs/msg/bool.hpp>
--#include <cv_bridge/cv_bridge.h>
-+#include <cv_bridge/cv_bridge.hpp>
- #include <iostream>
- // #include <ros/package.h>
- #include <ament_index_cpp/get_package_share_directory.hpp>
-diff --git a/loop_fusion/src/utility/CameraPoseVisualization.h b/loop_fusion/src/utility/CameraPoseVisualization.h
-index dbfae11..ef8164b 100755
---- a/loop_fusion/src/utility/CameraPoseVisualization.h
-+++ b/loop_fusion/src/utility/CameraPoseVisualization.h
-@@ -10,7 +10,7 @@
- #pragma once
- 
- #include <rclcpp/rclcpp.hpp>
--#include <std_msgs/msg/color_rgba.h>
-+#include <std_msgs/msg/color_rgba.hpp>
- #include <visualization_msgs/msg/marker.hpp>
- #include <visualization_msgs/msg/marker_array.hpp>
- #include <Eigen/Dense>
-diff --git a/vins/CMakeLists.txt b/vins/CMakeLists.txt
-index bcc560f..729c6f9 100755
---- a/vins/CMakeLists.txt
-+++ b/vins/CMakeLists.txt
-@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
- add_compile_options(-Wextra -Wpedantic)
- 
- set(CMAKE_BUILD_TYPE Release)
-+option(VINS_GPU_MODE "Enable CUDA-based feature tracking in vins" OFF)
- 
- # find dependencies
- find_package(ament_cmake REQUIRED)
-@@ -19,6 +20,7 @@ find_package(tf2_ros REQUIRED)
- find_package(cv_bridge REQUIRED)
- find_package(camera_models REQUIRED)
- find_package(image_transport REQUIRED)
-+find_package(message_filters REQUIRED)
- 
- 
- find_package(OpenCV REQUIRED)
-@@ -54,11 +56,17 @@ add_library(vins_lib
-     src/initial/initial_ex_rotation.cpp
-     src/featureTracker/feature_tracker.cpp)
- target_link_libraries(vins_lib  ${OpenCV_LIBS} ${CERES_LIBRARIES})
-+if(VINS_GPU_MODE)
-+  target_compile_definitions(vins_lib PRIVATE GPU_MODE)
-+  message(STATUS "vins GPU feature tracking enabled")
-+else()
-+  message(STATUS "vins GPU feature tracking disabled")
-+endif()
- 
- ament_target_dependencies(vins_lib rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport)
- 
- add_executable(vins_node src/rosNodeTest.cpp)
--ament_target_dependencies(vins_node rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport)
-+ament_target_dependencies(vins_node rclcpp rcpputils std_msgs visualization_msgs geometry_msgs nav_msgs tf2 tf2_ros cv_bridge camera_models image_transport message_filters)
- target_link_libraries(vins_node vins_lib) 
- 
- add_executable(kitti_odom_test src/KITTIOdomTest.cpp)
-diff --git a/vins/package.xml b/vins/package.xml
-index b79c04c..08b0e25 100755
---- a/vins/package.xml
-+++ b/vins/package.xml
-@@ -20,6 +20,7 @@
-   <depend>cv_bridge</depend>
-   <depend>camera_models</depend>
-   <depend>image_transport</depend>
-+  <depend>message_filters</depend>
- 
-   <test_depend>ament_lint_auto</test_depend>
-   <test_depend>ament_lint_common</test_depend>
-diff --git a/vins/src/KITTIOdomTest.cpp b/vins/src/KITTIOdomTest.cpp
-index d5ae538..d625bde 100755
---- a/vins/src/KITTIOdomTest.cpp
-+++ b/vins/src/KITTIOdomTest.cpp
-@@ -16,7 +16,7 @@
- #include <string>
- #include <rclcpp/rclcpp.hpp>
- #include <sensor_msgs/msg/image.hpp>
--#include <cv_bridge/cv_bridge.h>
-+#include <cv_bridge/cv_bridge.hpp>
- #include "estimator/estimator.h"
- #include "utility/visualization.h"
- 
 diff --git a/vins/src/estimator/estimator.cpp b/vins/src/estimator/estimator.cpp
-index 45d90c7..a4a9079 100755
+index e606bb7..5d54f2d 100755
 --- a/vins/src/estimator/estimator.cpp
 +++ b/vins/src/estimator/estimator.cpp
-@@ -174,7 +174,6 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
+@@ -174,14 +174,7 @@ void Estimator::inputImage(double t, const cv::Mat &_img, const cv::Mat &_img1)
          featureFrame = featureTracker.trackImage(t, _img);
      else
          featureFrame = featureTracker.trackImage(t, _img, _img1);
 -    //printf("featureTracker time: %f\n", featureTrackerTime.toc());
  
-     if (SHOW_TRACK)
+-    if (SHOW_TRACK)
+-    {
+-        cv::Mat imgTrack = featureTracker.getTrackImage();
+-        pubTrackImage(imgTrack, t);
+-    }
+-    
+     if(MULTIPLE_THREAD)  
+     {     
+         if(inputImageCnt % 2 == 0)
+@@ -215,7 +208,6 @@ void Estimator::inputIMU(double t, const Vector3d &linearAcceleration, const Vec
      {
-@@ -348,7 +347,7 @@ void Estimator::processMeasurements()
-             printStatistics(*this, 0);
+         mPropagate.lock();
+         fastPredictIMU(t, linearAcceleration, angularVelocity);
+-        pubLatestOdometry(latest_P, latest_Q, latest_V, t);
+         mPropagate.unlock();
+     }
+ }
+@@ -356,17 +348,9 @@ void Estimator::processMeasurements()
+             header.stamp.nanosec = nsec_ts;
  
-             std_msgs::msg::Header header;
--            header.frame_id = "world";
-+            header.frame_id = ODOM_FRAME;
+             pubOdometry(*this, header);
+-            // cout << "5-1" << endl;
+-            pubKeyPoses(*this, header);
+-            // cout << "5-2" << endl;
+-            pubCameraPose(*this, header);
+-            // cout << "5-3" << endl;
+             pubPointCloud(*this, header);
+-            // cout << "5-4" << endl;
+             pubKeyframe(*this);
+-            // cout << "5-5" << endl;
+             pubTF(*this, header);
+-            // cout << "5-6" << endl;
+             mProcess.unlock();
  
-             int sec_ts = (int)feature.first;
-             uint nsec_ts = (uint)((feature.first - sec_ts) * 1e9);
-@@ -454,8 +453,7 @@ void Estimator::processIMU(double t, double dt, const Vector3d &linear_accelerat
+ 
+@@ -454,8 +438,7 @@ void Estimator::processIMU(double t, double dt, const Vector3d &linear_accelerat
  void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<double, 7, 1>>>> &image, const double header)
  {
  
@@ -258,7 +130,7 @@ index 45d90c7..a4a9079 100755
  
      ROS_DEBUG("new image coming ------------------------------------------");
      ROS_DEBUG("Adding feature points %lu", image.size());
-@@ -591,7 +589,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
+@@ -591,7 +574,7 @@ void Estimator::processImage(const map<int, vector<pair<int, Eigen::Matrix<doubl
          // optimization
          TicToc t_solve;
          optimization();
@@ -267,7 +139,7 @@ index 45d90c7..a4a9079 100755
  
          set<int> removeIndex;
          outliersRejection(removeIndex);
-@@ -1008,18 +1006,17 @@ void Estimator::double2vector()
+@@ -1008,18 +991,17 @@ void Estimator::double2vector()
  
  bool Estimator::failureDetection()
  {
@@ -288,7 +160,7 @@ index 45d90c7..a4a9079 100755
      {
          ROS_INFO(" big IMU gyr bias estimation %f", Bgs[WINDOW_SIZE].norm());
          return true;
-@@ -1190,7 +1187,14 @@ void Estimator::optimization()
+@@ -1190,7 +1172,14 @@ void Estimator::optimization()
      ceres::Solve(options, &problem, &summary);
      //cout << summary.BriefReport() << endl;
      ROS_DEBUG("Iterations : %d", static_cast<int>(summary.iterations.size()));
@@ -304,21 +176,6 @@ index 45d90c7..a4a9079 100755
  
      double2vector();
      //printf("frame_count: %d \n", frame_count);
-diff --git a/vins/src/estimator/estimator.h b/vins/src/estimator/estimator.h
-index bf27b8c..f025c4a 100755
---- a/vins/src/estimator/estimator.h
-+++ b/vins/src/estimator/estimator.h
-@@ -11,8 +11,8 @@
-  
- #include <thread>
- #include <mutex>
--#include <std_msgs/msg/header.h>
--#include <std_msgs/msg/float32.h>
-+#include <std_msgs/msg/header.hpp>
-+#include <std_msgs/msg/float32.hpp>
- #include <ceres/ceres.h>
- #include <unordered_map>
- #include <queue>
 diff --git a/vins/src/estimator/feature_manager.cpp b/vins/src/estimator/feature_manager.cpp
 index d6022a4..e7bd4d1 100755
 --- a/vins/src/estimator/feature_manager.cpp
@@ -333,62 +190,8 @@ index d6022a4..e7bd4d1 100755
          {
              it_per_id.solve_flag = 2;
          }
-diff --git a/vins/src/estimator/parameters.cpp b/vins/src/estimator/parameters.cpp
-index 82992e9..b2562f3 100755
---- a/vins/src/estimator/parameters.cpp
-+++ b/vins/src/estimator/parameters.cpp
-@@ -34,6 +34,8 @@ std::string EX_CALIB_RESULT_PATH;
- std::string VINS_RESULT_PATH;
- std::string OUTPUT_FOLDER;
- std::string IMU_TOPIC;
-+std::string ODOM_FRAME;
-+std::string BODY_FRAME;
- int ROW, COL;
- double TD;
- int NUM_OF_CAM;
-@@ -97,6 +99,14 @@ void readParameters(std::string config_file)
-     USE_GPU = fsSettings["use_gpu"];
-     USE_GPU_ACC_FLOW = fsSettings["use_gpu_acc_flow"];
-     USE_GPU_CERES = fsSettings["use_gpu_ceres"];
-+#ifndef GPU_MODE
-+    if (USE_GPU || USE_GPU_ACC_FLOW)
-+    {
-+        ROS_WARN("GPU tracking requested in config, but vins was built without VINS_GPU_MODE. Falling back to CPU tracking.");
-+        USE_GPU = 0;
-+        USE_GPU_ACC_FLOW = 0;
-+    }
-+#endif
- 
-     USE_IMU = fsSettings["imu"];
-     printf("USE_IMU: %d\n", USE_IMU);
-@@ -117,6 +127,8 @@ void readParameters(std::string config_file)
-     MIN_PARALLAX = MIN_PARALLAX / FOCAL_LENGTH;
- 
-     fsSettings["output_path"] >> OUTPUT_FOLDER;
-+    if (OUTPUT_FOLDER.empty())
-+        OUTPUT_FOLDER = "/tmp";
-     VINS_RESULT_PATH = OUTPUT_FOLDER + "/vio.csv";
-     std::cout << "result path " << VINS_RESULT_PATH << std::endl;
-     std::ofstream fout(VINS_RESULT_PATH, std::ios::out);
-@@ -198,6 +210,16 @@ void readParameters(std::string config_file)
-     COL = fsSettings["image_width"];
-     ROS_INFO("ROW: %d COL: %d ", ROW, COL);
- 
-+    if (!fsSettings["odom_frame"].isNone())
-+        fsSettings["odom_frame"] >> ODOM_FRAME;
-+    else
-+        ODOM_FRAME = "world";
-+
-+    if (!fsSettings["body_frame"].isNone())
-+        fsSettings["body_frame"] >> BODY_FRAME;
-+    else
-+        BODY_FRAME = "body";
-+
-     if(!USE_IMU)
-     {
-         ESTIMATE_EXTRINSIC = 0;
 diff --git a/vins/src/estimator/parameters.h b/vins/src/estimator/parameters.h
-index 50ba1af..fb6dc83 100755
+index bdd505b..fb6dc83 100755
 --- a/vins/src/estimator/parameters.h
 +++ b/vins/src/estimator/parameters.h
 @@ -27,7 +27,7 @@ using namespace std;
@@ -400,15 +203,6 @@ index 50ba1af..fb6dc83 100755
  
  extern double INIT_DEPTH;
  extern double MIN_PARALLAX;
-@@ -52,6 +52,8 @@ extern std::string EX_CALIB_RESULT_PATH;
- extern std::string VINS_RESULT_PATH;
- extern std::string OUTPUT_FOLDER;
- extern std::string IMU_TOPIC;
-+extern std::string ODOM_FRAME;
-+extern std::string BODY_FRAME;
- extern double TD;
- extern int ESTIMATE_TD;
- extern int ROLLING_SHUTTER;
 diff --git a/vins/src/factor/projectionOneFrameTwoCamFactor.cpp b/vins/src/factor/projectionOneFrameTwoCamFactor.cpp
 index 8e24cfa..492b2ed 100755
 --- a/vins/src/factor/projectionOneFrameTwoCamFactor.cpp
@@ -729,214 +523,112 @@ index 3508bc0..8153ff3 100755
              }
              else
                  pts_velocity.push_back(cv::Point2f(0, 0));
-diff --git a/vins/src/rosNodeTest.cpp b/vins/src/rosNodeTest.cpp
-index 37bd75c..5267f6a 100755
---- a/vins/src/rosNodeTest.cpp
-+++ b/vins/src/rosNodeTest.cpp
-@@ -13,10 +13,14 @@
- #include <queue>
- #include <map>
- #include <thread>
-+#include <atomic>
- #include <mutex>
- #include <rclcpp/rclcpp.hpp>
--#include <cv_bridge/cv_bridge.h>
-+#include <cv_bridge/cv_bridge.hpp>
- #include <opencv2/opencv.hpp>
-+#include <message_filters/subscriber.h>
-+#include <message_filters/synchronizer.h>
-+#include <message_filters/sync_policies/approximate_time.h>
- #include "estimator/estimator.h"
- #include "estimator/parameters.h"
- #include "utility/visualization.h"
-@@ -28,6 +32,7 @@ queue<sensor_msgs::msg::PointCloud::ConstPtr> feature_buf;
- queue<sensor_msgs::msg::Image::ConstPtr> img0_buf;
- queue<sensor_msgs::msg::Image::ConstPtr> img1_buf;
- std::mutex m_buf;
-+std::atomic<bool> sync_running{true};
- 
- // header: 1403715278
- void img0_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
-@@ -38,11 +43,16 @@ void img0_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
-     m_buf.unlock();
- }
- 
--void img1_callback(const sensor_msgs::msg::Image::SharedPtr img_msg)
-+// Stereo synchronized callback: called by message_filters when both images
-+// arrive with matching timestamps. Pushes them to the queues atomically so
-+// sync_process always finds a ready matched pair (no timestamp comparison needed).
-+void stereo_img_callback(
-+    const sensor_msgs::msg::Image::ConstSharedPtr& img0_msg,
-+    const sensor_msgs::msg::Image::ConstSharedPtr& img1_msg)
- {
-     m_buf.lock();
--    // std::cout << "Right: " << img_msg->header.stamp.sec << "." << img_msg->header.stamp.nanosec << endl;
--    img1_buf.push(img_msg);
-+    img0_buf.push(img0_msg);
-+    img1_buf.push(img1_msg);
-     m_buf.unlock();
- }
- 
-@@ -73,7 +83,7 @@ cv::Mat getImageFromMsg(const sensor_msgs::msg::Image::ConstPtr &img_msg)
- // extract images with same timestamp from two topics
- void sync_process()
- {
--    while(1)
-+    while(sync_running.load())
-     {
-         if(STEREO)
-         {
-@@ -83,34 +93,19 @@ void sync_process()
-             m_buf.lock();
-             if (!img0_buf.empty() && !img1_buf.empty())
-             {
--                double time0 = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
--                double time1 = img1_buf.front()->header.stamp.sec + img1_buf.front()->header.stamp.nanosec * (1e-9);
--
--                // 0.003s sync tolerance
--                if(time0 < time1 - 0.003)
--                {
--                    img0_buf.pop();
--                    printf("throw img0\n");
--                }
--                else if(time0 > time1 + 0.003)
--                {
--                    img1_buf.pop();
--                    printf("throw img1\n");
--                }
--                else
-+                // Images are pre-synchronized by message_filters::ApproximateTime;
-+                // no timestamp comparison needed here.
-+                time = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
-+                header = img0_buf.front()->header;
-+                image0 = getImageFromMsg(img0_buf.front());
-+                img0_buf.pop();
-+                image1 = getImageFromMsg(img1_buf.front());
-+                img1_buf.pop();
-+                // Drop old buffered frames to keep up with real-time
-+                while(img0_buf.size() > 1 && img1_buf.size() > 1)
-                 {
--                    time = img0_buf.front()->header.stamp.sec + img0_buf.front()->header.stamp.nanosec * (1e-9);
--                    header = img0_buf.front()->header;
--                    image0 = getImageFromMsg(img0_buf.front());
-                     img0_buf.pop();
--                    image1 = getImageFromMsg(img1_buf.front());
-                     img1_buf.pop();
--                    // Drop old buffered frames to keep up with real-time
--                    while(img0_buf.size() > 1 && img1_buf.size() > 1)
--                    {
--                        img0_buf.pop();
--                        img1_buf.pop();
--                    }
-                 }
-             }
-             m_buf.unlock();
-@@ -279,12 +274,29 @@ int main(int argc, char **argv)
-         sub_imu = n->create_subscription<sensor_msgs::msg::Imu>(IMU_TOPIC, rclcpp::SensorDataQoS().keep_last(2000), imu_callback);
-     }
-     auto sub_feature = n->create_subscription<sensor_msgs::msg::PointCloud>("/feature_tracker/feature", rclcpp::QoS(rclcpp::KeepLast(2000)), feature_callback);
--    auto sub_img0 = n->create_subscription<sensor_msgs::msg::Image>(IMAGE0_TOPIC, rclcpp::SensorDataQoS(), img0_callback);
-+    // For stereo: use message_filters::ApproximateTimeSynchronizer so both
-+    // fisheye images are always delivered as a matched pair regardless of DDS
-+    // subscription jitter. For mono: use a plain subscription.
-+    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_img0_mono;
-+    std::shared_ptr<message_filters::Subscriber<sensor_msgs::msg::Image>> sub_img0_sync, sub_img1_sync;
-+    using SyncPolicy = message_filters::sync_policies::ApproximateTime<
-+        sensor_msgs::msg::Image, sensor_msgs::msg::Image>;
-+    std::shared_ptr<message_filters::Synchronizer<SyncPolicy>> stereo_sync;
- 
--    rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub_img1 = NULL;
-     if(STEREO)
-     {
--        sub_img1 = n->create_subscription<sensor_msgs::msg::Image>(IMAGE1_TOPIC, rclcpp::SensorDataQoS(), img1_callback);
-+        sub_img0_sync = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-+            n, IMAGE0_TOPIC, rmw_qos_profile_sensor_data);
-+        sub_img1_sync = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::Image>>(
-+            n, IMAGE1_TOPIC, rmw_qos_profile_sensor_data);
-+        stereo_sync = std::make_shared<message_filters::Synchronizer<SyncPolicy>>(
-+            SyncPolicy(10), *sub_img0_sync, *sub_img1_sync);
-+        stereo_sync->registerCallback(stereo_img_callback);
-+    }
-+    else
-+    {
-+        sub_img0_mono = n->create_subscription<sensor_msgs::msg::Image>(
-+            IMAGE0_TOPIC, rclcpp::SensorDataQoS(), img0_callback);
-     }
- 
-     auto sub_restart = n->create_subscription<std_msgs::msg::Bool>("/vins_restart", rclcpp::QoS(rclcpp::KeepLast(100)), restart_callback);
-@@ -292,9 +304,11 @@ int main(int argc, char **argv)
-     auto sub_cam_switch = n->create_subscription<std_msgs::msg::Bool>("/vins_cam_switch", rclcpp::QoS(rclcpp::KeepLast(100)), cam_switch_callback);
- 
-     std::thread sync_thread{sync_process};
-+    sync_thread.detach();
-     rclcpp::executors::MultiThreadedExecutor executor;
-     executor.add_node(n);
-     executor.spin();
-+    sync_running.store(false);
- 
-     return 0;
- }
-diff --git a/vins/src/utility/CameraPoseVisualization.h b/vins/src/utility/CameraPoseVisualization.h
-index f6a3a71..b0b1bb5 100755
---- a/vins/src/utility/CameraPoseVisualization.h
-+++ b/vins/src/utility/CameraPoseVisualization.h
-@@ -10,7 +10,7 @@
- #pragma once
- 
- #include <rclcpp/rclcpp.hpp>
--#include <std_msgs/msg/color_rgba.h>
-+#include <std_msgs/msg/color_rgba.hpp>
- #include <visualization_msgs/msg/marker.hpp>
- #include <visualization_msgs/msg/marker_array.hpp>
- #include <Eigen/Dense>
 diff --git a/vins/src/utility/visualization.cpp b/vins/src/utility/visualization.cpp
-index 98422b2..3fa4371 100755
+index df53026..9121de3 100755
 --- a/vins/src/utility/visualization.cpp
 +++ b/vins/src/utility/visualization.cpp
-@@ -59,7 +59,8 @@ void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, co
-     odometry.header.stamp.sec = sec_ts;
-     odometry.header.stamp.nanosec = nsec_ts;
+@@ -11,21 +11,13 @@
  
--    odometry.header.frame_id = "world";
-+    odometry.header.frame_id = ODOM_FRAME;
-+    odometry.child_frame_id = BODY_FRAME;
-     odometry.pose.pose.position.x = P.x();
-     odometry.pose.pose.position.y = P.y();
-     odometry.pose.pose.position.z = P.z();
-@@ -76,7 +77,7 @@ void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, co
- void pubTrackImage(const cv::Mat &imgTrack, const double t)
+ // using namespace ros;
+ using namespace Eigen;
+-rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odometry, pub_latest_odometry;
+-rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_path;
+-rclcpp::Publisher<sensor_msgs::msg::PointCloud>::SharedPtr pub_point_cloud, pub_margin_cloud;
+-rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr pub_key_poses;
+-rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_camera_pose;
+-rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_camera_pose_visual;
+-nav_msgs::msg::Path path;
++rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odometry;
++rclcpp::Publisher<sensor_msgs::msg::PointCloud>::SharedPtr pub_margin_cloud;
+ 
+ rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_keyframe_pose;
+ rclcpp::Publisher<sensor_msgs::msg::PointCloud>::SharedPtr pub_keyframe_point;
+ rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_extrinsic;
+ 
+-rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_image_track;
+-
+-CameraPoseVisualization cameraposevisual(1, 0, 0, 1);
+ static double sum_of_path = 0;
+ static Vector3d last_path(0.0, 0.0, 0.0);
+ 
+@@ -33,60 +25,11 @@ size_t pub_counter = 0;
+ 
+ void registerPub(rclcpp::Node::SharedPtr n)
  {
-     std_msgs::msg::Header header;
--    header.frame_id = "world";
-+    header.frame_id = ODOM_FRAME;
+-    pub_latest_odometry = n->create_publisher<nav_msgs::msg::Odometry>("imu_propagate", 10);
+-    pub_path = n->create_publisher<nav_msgs::msg::Path>("path", 10);
+     pub_odometry = n->create_publisher<nav_msgs::msg::Odometry>("odometry", 10);
+-    pub_point_cloud = n->create_publisher<sensor_msgs::msg::PointCloud>("point_cloud", 10);
+     pub_margin_cloud = n->create_publisher<sensor_msgs::msg::PointCloud>("margin_cloud", 10);
+-    pub_key_poses = n->create_publisher<visualization_msgs::msg::Marker>("key_poses", 10);
+-    pub_camera_pose = n->create_publisher<nav_msgs::msg::Odometry>("camera_pose", 10);
+-    pub_camera_pose_visual = n->create_publisher<visualization_msgs::msg::MarkerArray>("camera_pose_visual", 10);
+     pub_keyframe_pose = n->create_publisher<nav_msgs::msg::Odometry>("keyframe_pose", 10);
+     pub_keyframe_point = n->create_publisher<sensor_msgs::msg::PointCloud>("keyframe_point", 10);
+     pub_extrinsic = n->create_publisher<nav_msgs::msg::Odometry>("extrinsic", 10);
+-    pub_image_track = n->create_publisher<sensor_msgs::msg::Image>("image_track", 1);
+-
+-    cameraposevisual.setScale(0.1);
+-    cameraposevisual.setLineWidth(0.01);
+-}
+-
+-void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, const Eigen::Vector3d &V, double t)
+-{
+-    nav_msgs::msg::Odometry odometry;
+-
+-    int sec_ts = (int)t;
+-    uint nsec_ts = (uint)((t - sec_ts) * 1e9);
+-    odometry.header.stamp.sec = sec_ts;
+-    odometry.header.stamp.nanosec = nsec_ts;
+-
+-    odometry.header.frame_id = ODOM_FRAME;
+-    odometry.child_frame_id = BODY_FRAME;
+-    odometry.pose.pose.position.x = P.x();
+-    odometry.pose.pose.position.y = P.y();
+-    odometry.pose.pose.position.z = P.z();
+-    odometry.pose.pose.orientation.x = Q.x();
+-    odometry.pose.pose.orientation.y = Q.y();
+-    odometry.pose.pose.orientation.z = Q.z();
+-    odometry.pose.pose.orientation.w = Q.w();
+-    odometry.twist.twist.linear.x = V.x();
+-    odometry.twist.twist.linear.y = V.y();
+-    odometry.twist.twist.linear.z = V.z();
+-    pub_latest_odometry->publish(odometry);
+-}
+-
+-void pubTrackImage(const cv::Mat &imgTrack, const double t)
+-{
+-    std_msgs::msg::Header header;
+-    header.frame_id = ODOM_FRAME;
+-
+-    int sec_ts = (int)t;
+-    uint nsec_ts = (uint)((t - sec_ts) * 1e9);
+-    header.stamp.sec = sec_ts;
+-    header.stamp.nanosec = nsec_ts;
+-
+-    // sensor_msgs::msg::ImagePtr 
+-    sensor_msgs::msg::Image::SharedPtr imgTrackMsg = cv_bridge::CvImage(header, "bgr8", imgTrack).toImageMsg();
+-    pub_image_track->publish(*imgTrackMsg);
+ }
  
-     int sec_ts = (int)t;
-     uint nsec_ts = (uint)((t - sec_ts) * 1e9);
-@@ -138,8 +139,8 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
-     {
-         nav_msgs::msg::Odometry odometry;
-         odometry.header = header;
--        odometry.header.frame_id = "world";
--        odometry.child_frame_id = "world";
-+        odometry.header.frame_id = ODOM_FRAME;
-+        odometry.child_frame_id = BODY_FRAME;
-         Quaterniond tmp_Q;
-         tmp_Q = Quaterniond(estimator.Rs[WINDOW_SIZE]);
-         odometry.pose.pose.position.x = estimator.Ps[WINDOW_SIZE].x();
-@@ -156,10 +157,10 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
  
-         geometry_msgs::msg::PoseStamped pose_stamped;
-         pose_stamped.header = header;
--        pose_stamped.header.frame_id = "world";
-+        pose_stamped.header.frame_id = ODOM_FRAME;
-         pose_stamped.pose = odometry.pose.pose;
-         path.header = header;
--        path.header.frame_id = "world";
-+        path.header.frame_id = ODOM_FRAME;
-         path.poses.push_back(pose_stamped);
-         pub_path->publish(path);
+@@ -155,15 +98,6 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
+         odometry.twist.twist.linear.z = estimator.Vs[WINDOW_SIZE].z();
+         pub_odometry->publish(odometry);
  
-@@ -181,7 +182,7 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
+-        geometry_msgs::msg::PoseStamped pose_stamped;
+-        pose_stamped.header = header;
+-        pose_stamped.header.frame_id = ODOM_FRAME;
+-        pose_stamped.pose = odometry.pose.pose;
+-        path.header = header;
+-        path.header.frame_id = ODOM_FRAME;
+-        path.poses.push_back(pose_stamped);
+-        pub_path->publish(path);
+-
+         // write result to file
+         ofstream foutC(VINS_RESULT_PATH, ios::app);
+         foutC.setf(ios::fixed, ios::floatfield);
+@@ -182,112 +116,16 @@ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header
                << estimator.Vs[WINDOW_SIZE].z() << "," << endl;
          foutC.close();
          Eigen::Vector3d tmp_T = estimator.Ps[WINDOW_SIZE];
@@ -945,26 +637,113 @@ index 98422b2..3fa4371 100755
                                                            tmp_T.x(), tmp_T.y(), tmp_T.z(),
                                                            tmp_Q.w(), tmp_Q.x(), tmp_Q.y(), tmp_Q.z());
      }
-@@ -193,7 +194,7 @@ void pubKeyPoses(const Estimator &estimator, const std_msgs::msg::Header &header
-         return;
-     visualization_msgs::msg::Marker key_poses;
-     key_poses.header = header;
--    key_poses.header.frame_id = "world";
-+    key_poses.header.frame_id = ODOM_FRAME;
-     key_poses.ns = "key_poses";
-     key_poses.type = visualization_msgs::msg::Marker::SPHERE_LIST;
-     key_poses.action = visualization_msgs::msg::Marker::ADD;
-@@ -233,7 +234,8 @@ void pubCameraPose(const Estimator &estimator, const std_msgs::msg::Header &head
+ }
  
-         nav_msgs::msg::Odometry odometry;
-         odometry.header = header;
--        odometry.header.frame_id = "world";
-+        odometry.header.frame_id = ODOM_FRAME;
-+        odometry.child_frame_id = BODY_FRAME;
-         odometry.pose.pose.position.x = P.x();
-         odometry.pose.pose.position.y = P.y();
-         odometry.pose.pose.position.z = P.z();
-@@ -322,7 +324,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+-void pubKeyPoses(const Estimator &estimator, const std_msgs::msg::Header &header)
+-{
+-    if (estimator.key_poses.size() == 0)
+-        return;
+-    visualization_msgs::msg::Marker key_poses;
+-    key_poses.header = header;
+-    key_poses.header.frame_id = ODOM_FRAME;
+-    key_poses.ns = "key_poses";
+-    key_poses.type = visualization_msgs::msg::Marker::SPHERE_LIST;
+-    key_poses.action = visualization_msgs::msg::Marker::ADD;
+-    key_poses.pose.orientation.w = 1.0;
+-    key_poses.lifetime = rclcpp::Duration(0, 0);
+-
+-    //static int key_poses_id = 0;
+-    key_poses.id = 0; //key_poses_id++;
+-    key_poses.scale.x = 0.05;
+-    key_poses.scale.y = 0.05;
+-    key_poses.scale.z = 0.05;
+-    key_poses.color.r = 1.0;
+-    key_poses.color.a = 1.0;
+-
+-    for (int i = 0; i <= WINDOW_SIZE; i++)
+-    {
+-        geometry_msgs::msg::Point pose_marker;
+-        Vector3d correct_pose;
+-        correct_pose = estimator.key_poses[i];
+-        pose_marker.x = correct_pose.x();
+-        pose_marker.y = correct_pose.y();
+-        pose_marker.z = correct_pose.z();
+-        key_poses.points.push_back(pose_marker);
+-    }
+-    pub_key_poses->publish(key_poses);
+-}
+-
+-void pubCameraPose(const Estimator &estimator, const std_msgs::msg::Header &header)
+-{
+-    int idx2 = WINDOW_SIZE - 1;
+-
+-    if (estimator.solver_flag == Estimator::SolverFlag::NON_LINEAR)
+-    {
+-        int i = idx2;
+-        Vector3d P = estimator.Ps[i] + estimator.Rs[i] * estimator.tic[0];
+-        Quaterniond R = Quaterniond(estimator.Rs[i] * estimator.ric[0]);
+-
+-        nav_msgs::msg::Odometry odometry;
+-        odometry.header = header;
+-        odometry.header.frame_id = ODOM_FRAME;
+-        odometry.child_frame_id = BODY_FRAME;
+-        odometry.pose.pose.position.x = P.x();
+-        odometry.pose.pose.position.y = P.y();
+-        odometry.pose.pose.position.z = P.z();
+-        odometry.pose.pose.orientation.x = R.x();
+-        odometry.pose.pose.orientation.y = R.y();
+-        odometry.pose.pose.orientation.z = R.z();
+-        odometry.pose.pose.orientation.w = R.w();
+-
+-        pub_camera_pose->publish(odometry);
+-
+-        cameraposevisual.reset();
+-        cameraposevisual.add_pose(P, R);
+-        if(STEREO)
+-        {
+-            Vector3d P = estimator.Ps[i] + estimator.Rs[i] * estimator.tic[1];
+-            Quaterniond R = Quaterniond(estimator.Rs[i] * estimator.ric[1]);
+-            cameraposevisual.add_pose(P, R);
+-        }
+-        cameraposevisual.publish_by(pub_camera_pose_visual, odometry.header);
+-    }
+-}
+-
+ 
+ void pubPointCloud(const Estimator &estimator, const std_msgs::msg::Header &header)
+ {
+-    sensor_msgs::msg::PointCloud point_cloud, loop_point_cloud;
+-    point_cloud.header = header;
+-    loop_point_cloud.header = header;
+-
+-
+-    for (auto &it_per_id : estimator.f_manager.feature)
+-    {
+-        int used_num;
+-        used_num = it_per_id.feature_per_frame.size();
+-        if (!(used_num >= 2 && it_per_id.start_frame < WINDOW_SIZE - 2))
+-            continue;
+-        if (it_per_id.start_frame > WINDOW_SIZE * 3.0 / 4.0 || it_per_id.solve_flag != 1)
+-            continue;
+-        int imu_i = it_per_id.start_frame;
+-        Vector3d pts_i = it_per_id.feature_per_frame[0].point * it_per_id.estimated_depth;
+-        Vector3d w_pts_i = estimator.Rs[imu_i] * (estimator.ric[0] * pts_i + estimator.tic[0]) + estimator.Ps[imu_i];
+-
+-        geometry_msgs::msg::Point32 p;
+-        p.x = w_pts_i(0);
+-        p.y = w_pts_i(1);
+-        p.z = w_pts_i(2);
+-        point_cloud.points.push_back(p);
+-    }
+-    pub_point_cloud->publish(point_cloud);
+-
+-
+-    // pub margined potin
++    // Publish only the margined points that loop_fusion consumes.
+     sensor_msgs::msg::PointCloud margin_cloud;
+     margin_cloud.header = header;
+ 
+@@ -324,7 +162,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      return; // tmp.
  
  
@@ -972,7 +751,7 @@ index 98422b2..3fa4371 100755
      if( estimator.solver_flag != Estimator::SolverFlag::NON_LINEAR)
          return;
  
-@@ -333,30 +334,25 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+@@ -335,17 +172,15 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      // body frame
      Vector3d correct_t;
      Quaterniond correct_q;
@@ -994,12 +773,7 @@ index 98422b2..3fa4371 100755
  
  
      // transform.header.stamp = header.stamp;
--    transform.header.frame_id = "world";
--    transform.child_frame_id = "body";
-+    transform.header.frame_id = ODOM_FRAME;
-+    transform.child_frame_id = BODY_FRAME;
- 
-     transform.transform.translation.x = correct_t(0);
+@@ -356,9 +191,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      transform.transform.translation.y = correct_t(1);
      transform.transform.translation.z = correct_t(2);
  
@@ -1009,7 +783,7 @@ index 98422b2..3fa4371 100755
      q.setW(correct_q.w());
      q.setX(correct_q.x());
      q.setY(correct_q.y());
-@@ -366,18 +362,11 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+@@ -368,15 +200,8 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      transform.transform.rotation.z = q.z();
      transform.transform.rotation.w = q.w();
  
@@ -1024,12 +798,8 @@ index 98422b2..3fa4371 100755
 -
      // camera frame
      transform_cam.header.stamp = header.stamp;
--    transform_cam.header.frame_id = "body";
-+    transform_cam.header.frame_id = BODY_FRAME;
-     transform_cam.child_frame_id = "camera";
- 
- 
-@@ -397,12 +386,9 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+     transform_cam.header.frame_id = BODY_FRAME;
+@@ -399,9 +224,6 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
  
      // br->sendTransform(transform_cam);
  
@@ -1038,12 +808,8 @@ index 98422b2..3fa4371 100755
 -    
      nav_msgs::msg::Odometry odometry;
      odometry.header = header;
--    odometry.header.frame_id = "world";
-+    odometry.header.frame_id = ODOM_FRAME;
-     odometry.pose.pose.position.x = estimator.tic[0].x();
-     odometry.pose.pose.position.y = estimator.tic[0].y();
-     odometry.pose.pose.position.z = estimator.tic[0].z();
-@@ -412,9 +398,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
+     odometry.header.frame_id = ODOM_FRAME;
+@@ -414,9 +236,7 @@ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header)
      odometry.pose.pose.orientation.z = tmp_q.z();
      odometry.pose.pose.orientation.w = tmp_q.w();
  
@@ -1053,45 +819,39 @@ index 98422b2..3fa4371 100755
  
  }
  
-@@ -488,7 +472,7 @@ void pubKeyframe(const Estimator &estimator)
-         odometry.header.stamp.sec = sec_ts;
-         odometry.header.stamp.nanosec = nsec_ts;
- 
--        odometry.header.frame_id = "world";
-+        odometry.header.frame_id = ODOM_FRAME;
-         odometry.pose.pose.position.x = P.x();
-         odometry.pose.pose.position.y = P.y();
-         odometry.pose.pose.position.z = P.z();
-@@ -508,7 +492,7 @@ void pubKeyframe(const Estimator &estimator)
-         point_cloud.header.stamp.sec = sec_ts;
-         point_cloud.header.stamp.nanosec = nsec_ts;
- 
--        point_cloud.header.frame_id = "world";
-+        point_cloud.header.frame_id = ODOM_FRAME;
-         for (auto &it_per_id : estimator.f_manager.feature)
-         {
-             int frame_size = it_per_id.feature_per_frame.size();
-@@ -538,4 +522,4 @@ void pubKeyframe(const Estimator &estimator)
-         }
-         pub_keyframe_point->publish(point_cloud);
-     }
--}
-\ No newline at end of file
-+}
 diff --git a/vins/src/utility/visualization.h b/vins/src/utility/visualization.h
-index ab31748..6a13585 100755
+index 6a13585..d5914f5 100755
 --- a/vins/src/utility/visualization.h
 +++ b/vins/src/utility/visualization.h
-@@ -18,10 +18,10 @@
- #include <sensor_msgs/msg/image.hpp>
- // #include <sensor_msgs/image_encodings.h>
- #include "image_encodings.hpp"
--#include <cv_bridge/cv_bridge.h>
-+#include <cv_bridge/cv_bridge.hpp>
- #include <nav_msgs/msg/path.hpp>
- #include <nav_msgs/msg/odometry.hpp>
--#include <geometry_msgs/msg/point_stamped.h>
-+#include <geometry_msgs/msg/point_stamped.hpp>
- #include <visualization_msgs/msg/marker.hpp>
- #include <tf2_ros/transform_broadcaster.h>
- #include <tf2/LinearMath/Quaternion.h>
+@@ -33,31 +33,17 @@
+ #include <fstream>
+ 
+ extern rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odometry;
+-extern rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_path;
+-// extern ros::Publisher pub_cloud, pub_map;
+-extern rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr pub_key_poses;
+-// extern ros::Publisher pub_ref_pose, pub_cur_pose;
+-// extern ros::Publisher pub_key;
+-extern nav_msgs::msg::Path path;
+ extern rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_pose_graph; // maybe not used ??
+ extern int IMAGE_ROW, IMAGE_COL;
+ 
+ void registerPub(rclcpp::Node::SharedPtr n);
+ 
+-void pubLatestOdometry(const Eigen::Vector3d &P, const Eigen::Quaterniond &Q, const Eigen::Vector3d &V, double t);
+-
+-void pubTrackImage(const cv::Mat &imgTrack, const double t);
+-
+ void printStatistics(const Estimator &estimator, double t);
+ 
+ void pubOdometry(const Estimator &estimator, const std_msgs::msg::Header &header);
+ 
+ void pubInitialGuess(const Estimator &estimator, const std_msgs::msg::Header &header);
+ 
+-void pubKeyPoses(const Estimator &estimator, const std_msgs::msg::Header &header);
+-
+-void pubCameraPose(const Estimator &estimator, const std_msgs::msg::Header &header);
+-
+ void pubPointCloud(const Estimator &estimator, const std_msgs::msg::Header &header);
+ 
+ void pubTF(const Estimator &estimator, const std_msgs::msg::Header &header);

--- a/scripts/build_vins_gpu.sh
+++ b/scripts/build_vins_gpu.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-OPENCV_PREFIX="${OPENCV_PREFIX:-/workspace/docker_cache/opencv-cuda/current}"
+_ARCH="$(uname -m)"
+OPENCV_PREFIX="${OPENCV_PREFIX:-/workspace/docker_cache/opencv-cuda/${_ARCH}/current}"
 OPENCV_DIR="${OPENCV_DIR:-${OPENCV_PREFIX}/lib/cmake/opencv4}"
 
 if [[ ! -f "${OPENCV_DIR}/OpenCVConfig.cmake" ]]; then

--- a/src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml
+++ b/src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml
@@ -35,8 +35,11 @@ use_gpu_ceres: 0
 #   SDK extrinsic → rotation conjugation + translation remap → TF frames
 #   → optical frame rotation → body_T_cam.
 # See tools/compute_body_T_cam.py for the full computation.
+# Keep the measured T265 extrinsics fixed. Online refinement increases the
+# required startup excitation and hurts convergence when the camera is mostly
+# stationary during bringup on Jetson.
 # 0 = fix; 1 = refine online; 2 = calibrate from scratch.
-estimate_extrinsic: 1
+estimate_extrinsic: 0
 
 body_T_cam0: !!opencv-matrix
    rows: 4

--- a/src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml
+++ b/src/vins_fusion_bringup/config/t265_stereo_fisheye_imu.yaml
@@ -63,16 +63,16 @@ body_T_cam1: !!opencv-matrix
 multiple_thread: 1
 
 # Feature tracker parameters
-max_cnt: 150
-min_dist: 30
+max_cnt: 80
+min_dist: 25
 freq: 20
 F_threshold: 1.0
-show_track: 1
+show_track: 0
 flow_back: 1
 
 # Optimization parameters
-max_solver_time: 0.04
-max_num_iterations: 8
+max_solver_time: 0.025
+max_num_iterations: 4
 keyframe_parallax: 10.0
 
 # IMU parameters (seeded from BMI055-like noise levels; tune with Allan data if

--- a/src/vins_fusion_bringup/launch/vins_fusion.launch.py
+++ b/src/vins_fusion_bringup/launch/vins_fusion.launch.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Launch VINS-Fusion and adapt its raw odometry into the rover frame contract."""
 
+import platform
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -46,7 +48,7 @@ ARGUMENTS = [
     ),
     DeclareLaunchArgument(
         'opencv_prefix',
-        default_value='/workspace/docker_cache/opencv-cuda/current',
+        default_value=f'/workspace/docker_cache/opencv-cuda/{platform.machine()}/current',
         description='Prefix containing the optional CUDA-enabled OpenCV runtime for vins.',
     ),
 ]

--- a/src/vins_fusion_bringup/launch/vins_fusion.launch.py
+++ b/src/vins_fusion_bringup/launch/vins_fusion.launch.py
@@ -78,17 +78,10 @@ def generate_launch_description() -> LaunchDescription:
         },
         remappings=[
             ('odometry', raw_odom_topic),
-            ('path', '/vins/path'),
-            ('point_cloud', '/vins/point_cloud'),
             ('margin_cloud', '/vins/margin_cloud'),
-            ('key_poses', '/vins/key_poses'),
-            ('camera_pose', '/vins/camera_pose'),
-            ('camera_pose_visual', '/vins/camera_pose_visual'),
             ('keyframe_pose', '/vins/keyframe_pose'),
             ('keyframe_point', '/vins/keyframe_point'),
             ('extrinsic', '/vins/extrinsic'),
-            ('image_track', '/vins/image_track'),
-            ('imu_propagate', '/vins/imu_propagate'),
         ],
     )
 


### PR DESCRIPTION
## Summary
- package the latest VINS-Fusion stability/tuning changes into `patches/vins-fusion-ros2-jazzy.patch`
- trim unused VINS debug remappings from `vins_fusion.launch.py`
- add `docs/architecture/vins_fusion_vio.md` covering the x86_64 and Jetson Xavier CUDA setup, build flow, and measured performance

## Validation
- verified the regenerated VINS patch reverses cleanly against the current dirty `src/VINS-Fusion` worktree

## Notes
- this PR intentionally keeps the OpenSpec cuVSLAM proposal separate in #21
- I did not run the full Docker / colcon / AGENTS.md validation suite as part of packaging this branch
